### PR TITLE
Fix broken links

### DIFF
--- a/source/HMCTS-case-study.html.erb
+++ b/source/HMCTS-case-study.html.erb
@@ -12,7 +12,7 @@ title: HMCTS case study
       <h1 class="heading-xlarge">
           HM Courts & Tribunals Service case study
         </h1>
-        <img src="images/hmcts-case-study.png" width="100%" style="margin-bottom:30px;" alt="Illustration of MOJ Online form building tool" role="presentation">
+        <img src="/images/hmcts-case-study.png" width="100%" style="margin-bottom:30px;" alt="Illustration of MOJ Online form building tool" role="presentation">
         <p>
         In August 2019 HMCTS were faced with a problem. They had an online service for the public to submit complaints but it was provided by a third party and did not meet government accessibility or security standards. They had also purchased a new back office system to enable staff to manage complaints. The existing public-facing service was not capable of being integrated with the new back office system.
         </p>
@@ -37,7 +37,7 @@ title: HMCTS case study
         Before the launch of the new service the vast majority of complaints that HMCTS received came in via phone or email. After two months of operation the new online service was being used 350% more than the previous one and was being used just as much as the alternative channels.
         </p>
         <p>
-        Find out what <a href="features">features</a> you’ll get with MOJ Online and <a href="process">our process</a> for building and publishing online forms.
+        Find out what <a href="/features">features</a> you’ll get with MOJ Online and <a href="process">our process</a> for building and publishing online forms.
         </p>
       </div>
     </div>

--- a/source/features.html.erb
+++ b/source/features.html.erb
@@ -32,7 +32,7 @@ title: Features
          <p>The tool allows you to build a form tailored to your needs, including adding rules so the user sees different pages depending on the answers they give, and checking a user’s eligibility before they start.
          </p>
          <p>You also have the ability to add analytics so you can track and improve the form.</a></p>
-         <img src="images/product-page-screen.svg" alt="Illustration of MOJ Online form building tool" role="presentation">
+         <img src="/images/product-page-screen.svg" alt="Illustration of MOJ Online form building tool" role="presentation">
         <h2 id="direct-support">Direct support</h2>
         <p>
         We understand it can be daunting to launch new public services online, that’s why we provide quick and direct support throughout the process.
@@ -50,7 +50,7 @@ title: Features
         All forms built using the MOJ Online formbuilding tool meet legal <a href="https://www.gov.uk/guidance/accessibility-requirements-for-public-sector-websites-and-apps">accessibility</a> and <a href="https://www.gov.uk/service-manual/service-standard/point-9-create-a-secure-service">security</a> requirements for government.</p>
         </p>
       <p>
-      In <a href="process#build">the process of building a form</a>, we guide you through:</p>
+      In <a href="/process#build">the process of building a form</a>, we guide you through:</p>
     <ul>
       <li><a href="https://www.gov.uk/guidance/content-design/writing-for-gov-uk">writing content in plain English</a></li>
       <li>complying with the <a href="https://www.gov.uk/service-manual/service-standard">Digital Service Standard</a></li>

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -18,7 +18,7 @@ title: MOJ Online
         </a>
       </div>
       <div class="hero__aside-image">
-        <img src="images/moj-online-header-image.svg" alt="Illustration of MOJ Online publishing a form" role="presentation">
+        <img src="/images/moj-online-header-image.svg" alt="Illustration of MOJ Online publishing a form" role="presentation">
       </div>
     </div>
   </div>
@@ -38,7 +38,7 @@ title: MOJ Online
        </p>
       </div>
       <div class="column-one-half">
-        <img src="images/product-page-screen.svg" alt="Illustration of MOJ Online form building tool" role="presentation">
+        <img src="/images/product-page-screen.svg" alt="Illustration of MOJ Online form building tool" role="presentation">
       </div>
     </div>
 
@@ -50,7 +50,7 @@ title: MOJ Online
           <p>
             All forms built using the MOJ Online formbuilding tool meet legal <a href="https://www.gov.uk/guidance/accessibility-requirements-for-public-sector-websites-and-apps">accessibility</a> and <a href="https://www.gov.uk/service-manual/service-standard/point-9-create-a-secure-service">security</a> requirements for government.</p>
           <p>
-            In <a href="process#build">the process of building a form</a>, we guide teams through:</p>
+            In <a href="/process#build">the process of building a form</a>, we guide teams through:</p>
           <ul>
             <li><a href="https://www.gov.uk/guidance/content-design/writing-for-gov-uk">writing content in plain English</a></li>
             <li>complying with the <a href="https://www.gov.uk/service-manual/service-standard">Digital Service Standard</a></li>
@@ -93,10 +93,10 @@ title: MOJ Online
     <div class="column-one-half">
       <p>We helped a team in HMCTS to build and publish an online complaints form.</p>
       <p>The form was built and published in 4 weeks, replacing a legacy service with a form which meets legal accessibility and security requirements.</p>
-      <p>Read the <a href="HMCTS-case-study">HMCTS case study</a>.</p>
+      <p>Read the <a href="/HMCTS-case-study">HMCTS case study</a>.</p>
     </div>
     <div class="column-one-half">
-      <img src="images/hmcts-case-study.png" width="100%" alt="Illustration of MOJ Online form building tool" role="presentation">
+      <img src="/images/hmcts-case-study.png" width="100%" alt="Illustration of MOJ Online form building tool" role="presentation">
     </div>
 
   </div>

--- a/source/pricing.html.erb
+++ b/source/pricing.html.erb
@@ -22,7 +22,7 @@ title: Pricing
         Hosting is provided at cost by the MOJ Cloud Platform (price will vary by volume of transactions).
         </p>
         <p>
-        <a href="support">Get in touch</a> to discuss your project.
+        <a href="/support">Get in touch</a> to discuss your project.
       </div>
     </div>
   </div>

--- a/source/process.html.erb
+++ b/source/process.html.erb
@@ -44,7 +44,7 @@ title: Our process
       3. Build
       </h2>
       <p>
-      We’ll provide you with our <a href="features#the-formbuilding-tool">form building tool</a> and <a href="features#direct-support">direct training and support</a> allowing you to prototype your form.
+      We’ll provide you with our <a href="/features#the-formbuilding-tool">form building tool</a> and <a href="/features#direct-support">direct training and support</a> allowing you to prototype your form.
       </p>
       <h2 id="test">
       4. Test


### PR DESCRIPTION
Links to pages and images were broken as they were missing a `/`, for example `"/support"` was written `"support"`.