### PR TITLE
Revert Rack version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,7 +86,7 @@ GEM
       activesupport (>= 3.1)
     parallel (1.17.0)
     public_suffix (3.1.1)
-    rack (2.2.3)
+    rack (2.0.8)
     rack-livereload (0.3.17)
       rack
     rake (12.3.3)


### PR DESCRIPTION
Version of rack reverted back to 2.0.8 due to the Middleman build failing due to the upgraded gem.

https://github.com/middleman/middleman/issues/2309#issuecomment-580015535

Middleman creates static files for the Product Page which are hosted independently.