### PR TITLE
Remove transport font

### DIFF
--- a/source/pricing.html.erb
+++ b/source/pricing.html.erb
@@ -11,7 +11,7 @@ title: Pricing Page
           <h1 class="govuk-heading-l">Pricing</h1>
           <p class="govuk-body">We’ll provide a quote based on your needs and budget.</p>
           <p class="govuk-body">Hosting is provided by the MOJ Cloud Platform. The price of this will vary depending on the volume of transactions.</p>
-          <p class="govuk-body"><a href="/support">Contact us </a> to discuss your project.</p>
+          <p class="govuk-body"><a href="/support">Contact us</a> to discuss your project.</p>
         </div>
       </div>
     </section>

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -33,3 +33,35 @@ $govuk-assets-path: "/assets/govuk/assets/";
   padding-top: 45px;
   border-top: 1px #dee0e2 solid;
 }
+
+.hero__title {
+  font-family: Arial, Helvetica, sans-serif;
+}
+
+.hero__description {
+  font-family: Arial, Helvetica, sans-serif;
+}
+
+.govuk-heading-l {
+  font-family: Arial, Helvetica, sans-serif;
+}
+
+.govuk-heading-m {
+  font-family: Arial, Helvetica, sans-serif;
+}
+
+.govuk-body {
+  font-family: Arial, Helvetica, sans-serif;
+}
+
+.govuk-list {
+  font-family: Arial, Helvetica, sans-serif;
+}
+
+.govuk-button {
+  font-family: Arial, Helvetica, sans-serif;
+}
+
+.govuk-footer {
+  font-family: Arial, Helvetica, sans-serif;
+}


### PR DESCRIPTION
This website is on a domain that doesn't support the use of the GDS Transport font.

Before:
![Screen Shot 2020-08-07 at 14 51 59](https://user-images.githubusercontent.com/6122118/89652717-d019ed00-d8bd-11ea-8565-11074367d667.png)

The font has been replaced with Arial.

After:
![Screen Shot 2020-08-07 at 14 52 12](https://user-images.githubusercontent.com/6122118/89652742-da3beb80-d8bd-11ea-94ec-8c4bf46db81a.png)

A separate branch will deal with replacing the GOV.UK header with the MOJ header.