### PR TITLE
Add basic auth and robots.txt to staging only

### DIFF
--- a/.github/workflows/deploy_to_staging.yml
+++ b/.github/workflows/deploy_to_staging.yml
@@ -23,4 +23,5 @@ jobs:
         ECR_CREDENTIALS_SECRET: formbuilder-product-page-staging-ecr-credentials-output
         ECR_USERNAME: ${{ secrets.FB_PRODUCT_PAGE_ECR_USERNAME }}
         ECR_PASSWORD: ${{ secrets.FB_PRODUCT_PAGE_ECR_PASSWORD }}
+        BASIC_AUTH_STAGING: ${{ secrets.FB_BASIC_AUTH_STAGING }}
       run: ./scripts/build_and_push.sh

--- a/deploy/staging/ingress.yaml
+++ b/deploy/staging/ingress.yaml
@@ -2,6 +2,9 @@ apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: formbuilder-product-page-staging
+  annotations:
+    nginx.ingress.kubernetes.io/auth-type: basic
+    nginx.ingress.kubernetes.io/auth-secret: basic-auth
 spec:
   tls:
     - hosts:

--- a/deploy/templates/staging_robots.txt
+++ b/deploy/templates/staging_robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /

--- a/deploy/templates/staging_secret.yaml
+++ b/deploy/templates/staging_secret.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: basic-auth
+data:
+  auth: %BASIC_AUTH_STAGING%

--- a/scripts/build_and_push.sh
+++ b/scripts/build_and_push.sh
@@ -34,17 +34,11 @@ bundle exec middleman build
 
 if [ "$ENVIRONMENT" = "staging" ]; then
   echo 'Adding robots file to staging...'
-  echo "User-agent: *\nDisallow: /" > ./build/robots.txt
+  cp ./deploy/templates/staging_robots.txt ./build/robots.txt
 
   echo 'Adding basic auth secret file to staging...'
-  cat << EOF > ./deploy/staging/secret.yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: basic-auth
-data:
-  auth: ${BASIC_AUTH_STAGING}
-EOF
+  sed s/%BASIC_AUTH_STAGING%/${BASIC_AUTH_STAGING}/g \
+    ./deploy/templates/staging_secret.yaml > ./deploy/staging/secret.yaml
 fi
 
 echo  'Building docker image...'


### PR DESCRIPTION
We want to hide the staging environment behind basic auth and also not have it indexable by search engine robots.

Its unnecessary to use the environment in the image tag as the ECR repo URL is already specific for each environment.

https://trello.com/c/apSs8b5m/838-put-staging-product-page-behind-basic-auth-and-hide-from-search-engine-indexes

Co-authored-by: Matt Tei <matt.tei@digital.justice.gov.uk>