### PR TITLE
Updated production ingress rule to use the new mojo url.

### DIFF
--- a/deploy/prod/ingress.yaml
+++ b/deploy/prod/ingress.yaml
@@ -5,9 +5,9 @@ metadata:
 spec:
   tls:
     - hosts:
-        - formbuilder-product-page.apps.live-1.cloud-platform.service.justice.gov.uk
+        - moj-online.service.justice.gov.uk
   rules:
-  - host: formbuilder-product-page.apps.live-1.cloud-platform.service.justice.gov.uk
+  - host: moj-online.service.justice.gov.uk
     http:
       paths:
       - path: /


### PR DESCRIPTION
Last part of adding the mojo URL to the product page. Only the production ingress rules have been changed.