### PR TITLE
Updated production ingress rule to use the new mojo url.

### DIFF
--- a/deploy/prod/ingress.yaml
+++ b/deploy/prod/ingress.yaml
@@ -6,11 +6,20 @@ spec:
   tls:
     - hosts:
         - formbuilder-product-page.apps.live-1.cloud-platform.service.justice.gov.uk
+    - hosts:
+        - moj-online.service.justice.gov.uk
   rules:
   - host: formbuilder-product-page.apps.live-1.cloud-platform.service.justice.gov.uk
     http:
       paths:
       - path: /
         backend:
+          serviceName: formbuilder-product-page
+          servicePort: 4567
+  - host: moj-online.service.justice.gov.uk
+    http:
+      paths:
+      - path: /
+        bakend:
           serviceName: formbuilder-product-page
           servicePort: 4567


### PR DESCRIPTION
Updated production igress file as per https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/custom-domain-cert.html#obtaining-a-certificate to use the mojo url.