### PR TITLE
Lock Bundler to 2.1.4

### DIFF
--- a/scripts/build_and_push.sh
+++ b/scripts/build_and_push.sh
@@ -28,7 +28,7 @@ export ECR_REPO_URL=$(kubectl get secrets -n ${K8S_NAMESPACE} ${ECR_CREDENTIALS_
 
 npm install
 
-sudo gem install bundler
+sudo gem install bundler -v 2.1.4
 bundle install
 bundle exec middleman build
 


### PR DESCRIPTION
The latest version of bundler is not working on this image. For the moment lock bundler at 2.1.4.