### PR TITLE
Added moj-forms.service.justice.gov.uk to ingress

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# MOJ Online Product Page
+# MOJ Forms Product Page
 
 ![Deploy to Production](https://github.com/ministryofjustice/formbuilder-product-page/workflows/Deploy%20to%20Production/badge.svg)
 
-https://moj-online.service.justice.gov.uk
+https://moj-forms.service.justice.gov.uk
 
-For information on MOJ Online please contact moj-online@digital.justice.gov.uk.
+For information on MOJ Forms please contact moj-forms@digital.justice.gov.uk.
 
 ## Running Locally
 

--- a/deploy/prod/ingress.yaml
+++ b/deploy/prod/ingress.yaml
@@ -9,6 +9,8 @@ spec:
     - hosts:
       - moj-online.service.justice.gov.uk
       secretName: moj-online-product-page-prod-secret
+    - hosts:
+      - moj-forms.service.justice.gov.uk
   rules:
   - host: formbuilder-product-page.apps.live-1.cloud-platform.service.justice.gov.uk
     http:
@@ -18,6 +20,16 @@ spec:
           serviceName: formbuilder-product-page
           servicePort: 4567
   - host: moj-online.service.justice.gov.uk
+    # Previous product name URL - traffic still directed from this address
+    # Look at redirecting at the domain level in future
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: formbuilder-product-page
+          servicePort: 4567
+  - host: moj-forms.service.justice.gov.uk
+    # New Product name URL
     http:
       paths:
       - path: /

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "moj-online-product-page",
+  "name": "moj-forms-product-page",
   "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,32 @@
 {
   "name": "moj-online-product-page",
   "version": "1.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "moj-online-product-page",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "gaap-analytics": "^2.2.1",
+        "govuk-frontend": "^3.0.0"
+      }
+    },
+    "node_modules/gaap-analytics": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/gaap-analytics/-/gaap-analytics-2.2.1.tgz",
+      "integrity": "sha512-cnqQjqUt6wKM/nQvmw4maE+2Lodt/hftKWwUMOsPD2/pwwuKVgNpPLbmiXGowDxfwofj0GbSjd8jgvNWNjJjDg=="
+    },
+    "node_modules/govuk-frontend": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.0.0.tgz",
+      "integrity": "sha512-GCrEeaQZEnsthNtfmOUFlgsieNjHOeoamSWMdD4Gdq0RPxCA9uzfrT2i3jVnlBORekKjOL0C8eFZQBSNnjtz2A==",
+      "engines": {
+        "node": ">= 4.2.0"
+      }
+    }
+  },
   "dependencies": {
     "gaap-analytics": {
       "version": "2.2.1",

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -1,5 +1,5 @@
 ---
-title: MoJ Online
+title: MoJ Forms
 ---
 
 <div class="masthead">
@@ -62,10 +62,10 @@ title: MoJ Online
             <li>HM Courts and Tribunals Service (HMCTS)</li>
           </ul>
 
-          
+
         </div>
       </div>
-      
+
 
 
 


### PR DESCRIPTION
Ingress file updated for new host address.

The current URL will still point to the product page,
this is not ideal and will be resolved at a later date.

README updated to reflect new product name.

Frontmatter in the index page also updated to reflect
new product name.