### PR TITLE
Redirect added to httpd.conf for the cloud-platform url

### DIFF
--- a/deploy/prod/ingress.yaml
+++ b/deploy/prod/ingress.yaml
@@ -21,8 +21,6 @@ spec:
           serviceName: formbuilder-product-page
           servicePort: 4567
   - host: moj-online.service.justice.gov.uk
-    # Previous product name URL - traffic still directed from this address
-    # Look at redirecting at the domain level in future
     http:
       paths:
       - path: /
@@ -30,7 +28,6 @@ spec:
           serviceName: formbuilder-product-page
           servicePort: 4567
   - host: moj-forms.service.justice.gov.uk
-    # New Product name URL
     http:
       paths:
       - path: /

--- a/httpd.conf
+++ b/httpd.conf
@@ -527,6 +527,11 @@ LogLevel warn
 	RedirectPermanent / https://moj-forms.service.justice.gov.uk
 </VirtualHost>
 
+<VirtualHost *:80>
+	ServerName formbuilder-product-page.apps.live-1.cloud-platform.service.justice.gov.uk
+	RedirectPermanent / https://moj-forms.service.justice.gov.uk
+</VirtualHost>
+
 # Local access to the Apache HTTP Server Manual
 #Include conf/extra/httpd-manual.conf
 


### PR DESCRIPTION
1. Added formbuilder-product-page.apps.live-1.cloud-platform.service.justice.gov.uk
to redirect to the moj-forms.serive.justice.gov.uk url.
2. Removed comments in the ingress file as they are no longer needed.