### PR TITLE
Changed the ingress to perform a redirect to the correct URL

### DIFF
--- a/deploy/prod/ingress.yaml
+++ b/deploy/prod/ingress.yaml
@@ -1,6 +1,9 @@
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/rewrite-target: https://moj-forms.service.justice.gov.uk$1$2
   name: formbuilder-product-page
 spec:
   tls:
@@ -20,9 +23,7 @@ spec:
         backend:
           serviceName: formbuilder-product-page
           servicePort: 4567
-  - host: moj-online.service.justice.gov.uk
-    # Previous product name URL - traffic still directed from this address
-    # Look at redirecting at the domain level in future
+  - host: nginx.redirect
     http:
       paths:
       - path: /


### PR DESCRIPTION
After rebranding the product page to match the product, the old moj-online URL
pointed to the product page. To make it clearer the URL should redirect to the
new moj-forms URL.

After speaking to the Cloud Platform team, they suguested this solution.

https://www.linuxrecruit.co.uk/blog?title=Kubernetes%20Nginx%20Ingress%3A%20Traffic%20Redirect%20Using%20Annotations%20Demystified&id=132