### PR TITLE
Removed the moj-online url from the ingress

### DIFF
--- a/deploy/prod/ingress.yaml
+++ b/deploy/prod/ingress.yaml
@@ -7,22 +7,10 @@ spec:
     - hosts:
       - formbuilder-product-page.apps.live-1.cloud-platform.service.justice.gov.uk
     - hosts:
-      - moj-online.service.justice.gov.uk
-      secretName: moj-online-product-page-prod-secret
-    - hosts:
       - moj-forms.service.justice.gov.uk
       secretName: moj-forms-product-page-prod-secret
   rules:
   - host: formbuilder-product-page.apps.live-1.cloud-platform.service.justice.gov.uk
-    http:
-      paths:
-      - path: /
-        backend:
-          serviceName: formbuilder-product-page
-          servicePort: 4567
-  - host: moj-online.service.justice.gov.uk
-    # Previous product name URL - traffic still directed from this address
-    # Look at redirecting at the domain level in future
     http:
       paths:
       - path: /


### PR DESCRIPTION
https://trello.com/c/5rJj1mso

Although not the best solution, this change removes the old URL which
was associated with the product's old branding and team name.

This would of been a domain redirect which could not be done at the
ingress for the namespace and caused an error.