### PR TITLE
Upgrade to govuk-frontend 4.3.1 and fix mobile navigation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "gaap-analytics": "^2.2.1",
-        "govuk-frontend": "^4.2.0"
+        "govuk-frontend": "^4.3.0"
       }
     },
     "node_modules/gaap-analytics": {
@@ -19,9 +19,9 @@
       "integrity": "sha512-cnqQjqUt6wKM/nQvmw4maE+2Lodt/hftKWwUMOsPD2/pwwuKVgNpPLbmiXGowDxfwofj0GbSjd8jgvNWNjJjDg=="
     },
     "node_modules/govuk-frontend": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.2.0.tgz",
-      "integrity": "sha512-IHbnz5DbnPjuCv4lQvtJGoCNAKAN6byKqmaej8hjd6Y/KTaAuw10npijeqfRJNO4WdDX9a34+n+SC/UmWdjfGQ==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.3.1.tgz",
+      "integrity": "sha512-uD0KVFds7drOwLEvfp4zRBOXuHCxkWLYDQcYvlbG+2baZ9po2TGZz8WjfzhfueYjo9+Uwk+bM0NQT6g4cg/Q+A==",
       "engines": {
         "node": ">= 4.2.0"
       }
@@ -34,9 +34,9 @@
       "integrity": "sha512-cnqQjqUt6wKM/nQvmw4maE+2Lodt/hftKWwUMOsPD2/pwwuKVgNpPLbmiXGowDxfwofj0GbSjd8jgvNWNjJjDg=="
     },
     "govuk-frontend": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.2.0.tgz",
-      "integrity": "sha512-IHbnz5DbnPjuCv4lQvtJGoCNAKAN6byKqmaej8hjd6Y/KTaAuw10npijeqfRJNO4WdDX9a34+n+SC/UmWdjfGQ=="
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.3.1.tgz",
+      "integrity": "sha512-uD0KVFds7drOwLEvfp4zRBOXuHCxkWLYDQcYvlbG+2baZ9po2TGZz8WjfzhfueYjo9+Uwk+bM0NQT6g4cg/Q+A=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,6 @@
   "homepage": "https://github.com/alphagov/product-page-example#readme",
   "dependencies": {
     "gaap-analytics": "^2.2.1",
-    "govuk-frontend": "^4.2.0"
+    "govuk-frontend": "^4.3.0"
   }
 }

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -43,10 +43,10 @@
           </a>
         </div>
         <div class="govuk-header__content">
-          <button type="button" role="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
 
-          <nav>
-            <ul id="navigation" class="govuk-header__navigation " aria-label="Navigation menu">
+          <nav class="govuk-header__navigation" aria-label="Navigation menu">
+            <button type="button" role="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation" hidden>Menu</button>
+            <ul id="navigation" class="govuk-header__navigation-list">
               <% pages_by_menu('top').each do |page| %>
                 <% if page.url == current_page.url %>
                   <li class="govuk-header__navigation-item govuk-header__navigation-item--active">


### PR DESCRIPTION
Simple PR updating govuk-frontend to the latest version and applying a fix to make the mobile nav work again and have the correct styling.