### PR TITLE
Stop using the beta versions of kubernetes ingress controllers

### DIFF
--- a/deploy/prod/ingress.yaml
+++ b/deploy/prod/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: formbuilder-product-page
@@ -26,6 +26,9 @@ spec:
     http:
       paths:
       - path: /
+        pathType: ImplementationSpecific
         backend:
-          serviceName: formbuilder-product-page
-          servicePort: 4567
+          service:
+            name: formbuilder-product-page
+            port:
+              number: 4567

--- a/deploy/staging/ingress.yaml
+++ b/deploy/staging/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: formbuilder-product-page-staging
@@ -17,6 +17,9 @@ spec:
     http:
       paths:
       - path: /
+        pathType: ImplementationSpecific
         backend:
-          serviceName: formbuilder-product-page-staging
-          servicePort: 4567
+          service:
+            name: formbuilder-product-page-staging
+            port:
+              number: 4567


### PR DESCRIPTION
All beta Ingress API versions such as extensions/v1beta1 and networking.k8s.io/v1beta1 have been deprecated and are not available in Kubernetes v1.22 or the new nginx-ingress-controller v1.2

Change the apiVersion to networking.k8s.io/v1

Add pathType: ImplementationSpecific after path: /

For serviceName, rename -backend.serviceName to -backend.service.name

For String servicePort, rename -backend.servicePort to -backend.service.port.name

For Numeric servicePort, rename -backend.servicePort to -backend.service.port.number