### PR TITLE
Removing long liveed credentials from the ecr login

### DIFF
--- a/scripts/build_and_push.sh
+++ b/scripts/build_and_push.sh
@@ -97,12 +97,11 @@ echo $out
 echo "**********************************"
 echo
 
-echo  '*** Building docker image... ***'
-login="$(AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION} AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} aws ecr get-login --no-include-email)"
-${login}
-echo "**********************************"
+echo  '*** logging in to ECR... ***'
+login=$(AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION} AWS_IAM_ROLE_ARN=${ECR_ROLE_TO_ASSUME_STAGING} aws ecr get-login-password --region ${AWS_DEFAULT_REGION} | docker login --username AWS --password-stdin ${AWS_ECR_REGISTRY_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com)
+echo $login
+echo "**********************************" 
 echo
-
 echo '*** Pushing docker image... ***'
 out=$(docker push ${ECR_REPO_URL}:latest)
 echo $out

--- a/source/building-and-editing.html.erb
+++ b/source/building-and-editing.html.erb
@@ -16,6 +16,7 @@ order: 3
         <p>Learn how to start building your first form.</p>
         <p><a class="govuk-link" href="#form-name">Naming your form</a><br>
         <a class="govuk-link" href="#start-page">Starting pages</a><br>
+        <a class="govuk-link" href="#footer">Footer pages</a><br>
         <a class="govuk-link" href="#preview">Previewing your pages<a/><br>
         <a class="govuk-link" href="#adding-pages">Adding pages</a><br>
         <a class="govuk-link" href="#moving-pages">Moving pages</a><br>
@@ -77,8 +78,6 @@ order: 3
         </li>
         <p><a class="govuk-link" href="#top">Back to top</a></p>
       </section>
-
-
       <section class="content-section content-section--with-top-border">
       <h2 id="footer" class="govuk-heading-m">Footer pages</h2>
       <p>Your form contains 3 pages that are linked from the footer section of every page of your form. These can be seen in the flow view under the heading of "form footer". They are:</p>

--- a/source/building-and-editing.html.erb
+++ b/source/building-and-editing.html.erb
@@ -65,6 +65,7 @@ order: 3
         <li>check answers page</li>
         <li>confirmation page</li>
         </ul>
+        <p>The <a class="govuk-link" href="#footer">form footer</a> section also contains some pages which are required for your form and linked from your form's footer section.</p>
         <img src="/images/start-pages.png" alt="A new form is created with a start page, check answers page and confirmation page." class="screenshot-image">
         <p>The start page is your form's home page and cannot be deleted. To find out more about what should go on your start page, read the <a class="govuk-link" href="https://design-system.service.gov.uk/patterns/start-pages/">Design System guidance</a>.</p>
         <p>All your form's question pages should come after the start page and before the check answers page.</p>
@@ -76,7 +77,22 @@ order: 3
         </li>
         <p><a class="govuk-link" href="#top">Back to top</a></p>
       </section>
+
+
       <section class="content-section content-section--with-top-border">
+      <h2 id="footer" class="govuk-heading-m">Footer pages</h2>
+      <p>Your form contains 3 pages that are linked from the footer section of every page of your form. These can be seen in the flow view under the heading of "form footer". They are:</p>
+      <ul>
+      <li>Cookies</li>
+      <li>Privacy</li>
+      <li>Accessibility</li>
+      </ul>
+      <p>These pages are required for every form so cannot be deleted or moved.</p>
+      <p>The cookies page doesn't require any input from you so can't be edited. However, the privacy and accessibility pages contain boilerplate copy with sections in square brackets - [like this] - that you need to fill in. the page names are highlighted in red to show that they are incomplete. The warnings will disappear when the sections have all been completed.<p>
+      Refer to the sections on <a class="govuk-link" href="/accessibility">accessibility</a> and <a class="govuk-link" href="/data-protection">data protection</a> for help completing these pages.</p>
+      <p><a class="govuk-link" href="#top">Back to top</a></p>
+    </section>
+    <section class="content-section content-section--with-top-border">
       <h2 id="preview" class="govuk-heading-m">Previewing your form</h2>
       <p>The flow view includes a 'Preview' button in the top right-hand corner.</p>
       <p>Previewing your form is a quick way to check how the form will look and work without needing to publish it. Most things in preview will behave identically to the final published form but there are a few limitations:</p> 

--- a/source/building-and-editing.html.erb
+++ b/source/building-and-editing.html.erb
@@ -27,12 +27,10 @@ order: 3
         <a class="govuk-link" href="#file-upload">Asking users to submit a file</a><br>
         <a class="govuk-link" href="#optional">Making a question optional</a><br>
         <a class="govuk-link" href="#validation">Validating user answers</a><br>
-        <a class="govuk-link" href="#markdown">Formatting content with markdown</a></p>
+        <a class="govuk-link" href="#markdown">Formatting content with markdown</a><br>
+        <a class="govuk-link" href="#welsh-translation">Translating a form into Welsh</a></p>
       <section class="content-section content-section--with-top-border">
         <h2 id="form-name" class="govuk-heading-m">Naming your form</h2>
-        
-        
-        
         <p>When you create a new form, you need to give it a name.</p>
         <p>This name is:</p>
         <ul>
@@ -456,7 +454,25 @@ order: 3
 <p>For the full range of markdown options available, see this <a class="govuk-link" href="https://www.markdownguide.org">markdown guide</a>.</p>
 <p><a class="govuk-link" href="#top">Back to top</a></p>
 </section>
-
+<section class="content-section content-section--with-top-border">
+        <h2 id="welsh-translation" class="govuk-heading-m">Translating a form into Welsh</h2>
+        <p>It's possible to create a separate version of a form for Welsh-language users, although the process is currently quite manual.</p>
+        <p>You will need to:</p>
+        <ul>
+        <li><a class="govuk-link" href="/contact">contact us</a> to create a copy of your form</li>
+        <li>arrange the translation yourself</li>
+        <li>update the copy of your form with the translated text</li>
+        <li>add links to the start pages of the English and Welsh forms allowing users to switch between languages</li>
+        <li>keep both versions in sync if you make any changes</li>
+        </ul>
+        <p>The current limitations of this approach are:</p>
+        <ul>
+        <li>the 2 forms are completely separate and users will be unable to switch between the languages during completion</li>
+        <li>any wording present in the form's template, such as button text and error messages, will not be translated</li>
+        </ul>
+        <p>We plan to explore and improve the way that MoJ Forms supports translations in the future.</p>
+        <p><a class="govuk-link" href="#top">Back to top</a></p>
+      </section>
         <!-- END CONTENT -->
       </div>
     </div>

--- a/source/contact.html.erb
+++ b/source/contact.html.erb
@@ -7,31 +7,36 @@ menuindex: 4
 
 <main class="govuk-main-wrapper govuk-body" id="main-content" role="main">
   <div class="govuk-width-container">
-
     <section class="content-section">
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
           <h1 class="govuk-heading-l">Contact us</h1>
             <h2>New to MoJ Forms?</h2>
-              <p>Complete our contact form to:</p>
+              <p><a class="govuk-link" href="https://contact-moj-forms.form.service.justice.gov.uk/">Contact MoJ Forms</a> to:</p>
               <ul>
               <li>take part in the private beta</li>
               <li>request a demo</li>
               <li>discuss an opportunity</li>
               <li>learn more about MoJ Forms features, capabilities or timescales</li>
               </ul>
-              <p><a class="govuk-link" href="https://contact-moj-forms.form.service.justice.gov.uk/">Contact MoJ Forms</a></p>
-            <h2>Help and support</h2>
-              <p>For questions about using MoJ Forms or for any technical problems:</p>
+            <h2>Help, support and feedback</h2>
+              <p>For comments and questions about using MoJ Forms or for any technical problems:</p>
               <ul>
               <li>email: <a class="govuk-link" href="mailto:moj-forms@digital.justice.gov.uk">moj-forms@digital.justice.gov.uk</a></li>
               <li>Slack: <a class="govuk-link" href="https://mojdt.slack.com/messages/CE26QEL1Z/">#ask-formbuilder on mojdt.slack.com</a></li>
+              </ul>
+              <p>When reporting a fault or bug, make sure to include:</p>
+              <ul>
+              <li>what you expected to happen</li>
+              <li>what actually happened</li>
+              <li>what steps to take to reproduce the behaviour</li>
+              <li>the browser version and operating system you are using</li>
+              <li>screenshots of any relevant pages and messages</li>
               </ul>
               <p>We will respond as soon as possible. Our working hours are Monday to Friday, 9am to 5pm, excluding bank holidays.</p>
         </div>
       </div>
     </section>
-
   </div>
 </main>
 

--- a/source/features.html.erb
+++ b/source/features.html.erb
@@ -78,7 +78,6 @@ menuindex: 1
                 </td>
                 <td>We are currently working on:
                   <ul>
-                    <li>allowing users to edit their form name and URL</li>
                     <li>introducing a process for performing final checks on new forms before they go live</li>
                     <li>improving the accessibility of the editor</li>
                   </ul>
@@ -88,6 +87,7 @@ menuindex: 1
                     <li>integrate forms with other services using an API</li>  
                     <li>allow multiple users to work on the same form</li>
                     <li>enable form owners to unpublish and delete forms</li>
+                    <li>support Welsh-language versions of forms</li>
                   </ul>
                 </td>
               </tr>

--- a/source/getting-started.html.erb
+++ b/source/getting-started.html.erb
@@ -50,6 +50,20 @@ order: 2
     <li>to use as the reply address on confirmation emails</li>
     </ul>
     <p>These can be the same or different and will need to be verified as you are building and setting up your form.</p>
+
+    <h3 class="govuk-heading-s">Welsh language support</h3>
+    <p>UK government departments that provide services in Wales are required to treat the Welsh and English languages equally. That means you may need to translate your form into Welsh and provide support to users in Welsh.</p>
+    <p>MoJ has several Welsh Language Schemes which explain our policy on translating and providing services in Welsh: 
+    <ul>
+    <li><a class="govuk-link" href="https://www.gov.uk/government/publications/moj-welsh-language-scheme-2018">MoJ Welsh language scheme 2018</a></li>
+    <li><a class="govuk-link" href="https://www.gov.uk/government/publications/hmpps-welsh-language-scheme-2020-to-2023">HMPPS Welsh language scheme 2020 to 2023</a></li>
+    <li><a class="govuk-link" href="https://www.gov.uk/government/organisations/hm-courts-and-tribunals-service/about/welsh-language-scheme">HMCTS Welsh language scheme</a></li>
+    <li><a class="govuk-link" href="https://www.gov.uk/government/organisations/criminal-injuries-compensation-authority/about/welsh-language-scheme">CICA Welsh language scheme</a></li>
+    <li><a class="govuk-link" href="https://www.gov.uk/government/organisations/office-of-the-public-guardian/about/welsh-language-scheme">OPG Welsh language scheme</a></li>
+    </ul>
+    <p>When deciding whether to translate a form, follow your agency's Welsh language scheme and look for evidence of a user need, such as high volumes of Welsh users or requests for translations from Welsh-language speakers.</p>
+    <p>You will need to source your own translations and enter these manually into a separate version of your form. See <a class="govuk-link" href="/building-and-editing#welsh-translation">Translating a form into Welsh</a> for details. You may also need to consider processes and resources for handling and responding to users in Welsh.</p>
+    <p>Your local GOV.UK publishing team will be able to advise you on sourcing translations.</p>
     <h3 id="assessments" class="govuk-heading-s">Getting assessed</h3>
     <p>Government digital services usually go through a service assessment. This is a process managed by the Central Digital and Data Office (CDDO) and each government department to ensure all government services are built to the same standard.</p>
     <p>Forms built with a form-building service like MoJ Forms are an exception. Your form will only need to go through a service assessment if one or more of the following apply:</p> 

--- a/source/news.html.erb
+++ b/source/news.html.erb
@@ -15,6 +15,36 @@ menuindex: 2
     </div>
   </div>
   </section>
+
+
+
+
+  <section class="content-section content-section--with-top-border">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+    <p>9 August 2023</p>
+    <h2 id="navigation-help-09082023" class="govuk-heading-m">Help navigating large forms</h2>
+    <p>A couple of recent new features should make navigating and managing large forms a little easier.</p>
+    <p>It's now possible to highlight up to 2 connection paths at a time to make it easier to follow them. In simple forms, it's easy to see how one page is connected to another but this gets harder as a form grows. Some connections can grow quite long as they loop around other pages and it can be hard to follow them, particularly if you need to scroll through the form at the same time.</p>
+    <p>You now have 2 ways to highlight these connections:</p>
+    <ul>
+    <li>move the mouse pointer over a connection, which makes it bold and blue only while the mouse pointer is on the line</li>
+    <li>click a connection, which makes it bold and orange even while you move around the flow view - the arrow will stay orange until you click it again, click a different arrow or leave the flow view</li>
+    </ul>
+    <p>You can use both of these options at the same time to track and compare 2 different connections.</p>
+    <p>In addition to these options, MoJ Forms now remembers your position in the flow view when you open a page to edit it or perform actions like moving or deleting pages. When you have finished with your edits or actions and return to the flow view, you will be taken back to your previous position. No more having to scroll from the beginning of your form every time.</p>    
+    <p><a class="govuk-link" href="#top">Back to top</a></p>
+    </div>
+  </div>
+</section>
+
+
+
+
+
+
+
+
   <section class="content-section content-section--with-top-border">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">

--- a/source/user-guide.html.erb
+++ b/source/user-guide.html.erb
@@ -37,10 +37,7 @@ menuindex: 3
       </section>
        <section class="content-section content-section--with-top-border">
         <h2 id="issues" class="govuk-heading-m">Known issues</h2>
-        <p>MoJ Forms is a new platform with a range of features that we are working to expand. In the short term, you might encounter some limitations.
-        <h3 class="govuk-heading-s">Email settings</h3> 
-        <p>All emails (both submission emails and confirmation emails) are being sent from no-reply-moj-forms@digital.justice.gov.uk - regardless of the address set as the <a class="govuk-link" href="/settings/#from-address">'from' address</a>. This is to prevent emails potentially being blocked or going into spam. The 'from' address continues to be the 'reply to' address for these emails.</p>
-        <h3 class="govuk-heading-s">Other issues</h3>
+        <p>MoJ Forms is a new platform with a range of features that we are working to expand. In the short term, you might encounter some limitations, including:
         <ul>
         <li>Password-protected forms can't be opened in Edge on DOM1 machines. We recommend using a different browser for testing and avoiding password protection on live forms.</li>
         <li>It's not currently possible to rename a page (the URL slug that you set when <a class="govuk-link" href="/building-and-editing/#adding-pages">adding a page</a>). <a class="govuk-link" href="/contact/">Contact us</a> to change this.</li>
@@ -50,23 +47,12 @@ menuindex: 3
       </section>
       <section class="content-section content-section--with-top-border">
           <h2 id="help" class="govuk-heading-m">Get help or report a bug</h2>
-        <p>If you need help doing something or think you have found a bug (something doesn’t work as you expected), <a class="govuk-link" href="/contact/">Contact us by email or on Slack</a>.
-        <p>When reporting a bug, make sure to include:</p>
-        <ul>
-        <li>what you expected to happen</li>
-        <li>what actually happened</li>
-        <li>what steps to take to reproduce the behaviour</li>
-        <li>the browser version and operating system you are using</li>
-        <li>screenshots of any relevant pages and messages</li>
-        </ul>
+        <p>If you need help doing something or think you have found a bug (something doesn’t work as you expected), <a class="govuk-link" href="/contact/">contact us by email or on Slack</a>.</p>
         <p><a class="govuk-link" href="#top">Back to top</a></p>
       </section>
       <section class="content-section content-section--with-top-border">
         <h2 id="feedback" class="govuk-heading-m">Give feedback</h2>
-        <p>You can send feedback at any time using the red feedback button on the right hand side of the screen, as shown here:</p>
-        <img src="/images/give-feedback.png" alt="The red feedback button will appear on every page in MoJ Forms so you can provide feedback at any point." class="screenshot-image">
-        <p>This appears on every page, so you can provide feedback on whatever you are doing.</p>
-        <p>Certain actions or URLs may trigger specific questions from us. You'll see these as on-page surveys.</p>
+        <p><a class="govuk-link" href="/contact/">Contact us by email or on Slack</a> to tell u s what you think of MoJ Forms and suggest improvements.</p>
         <p><a class="govuk-link" href="#top">Back to top</a></p>
       </section>
         <!-- END CONTENT -->

--- a/source/user-guide.html.erb
+++ b/source/user-guide.html.erb
@@ -31,6 +31,7 @@ menuindex: 3
         <li>@cica.gov.uk</li>
         <li>@judicialappointments.gov.uk</li>
         <li>@ospt.gov.uk</li>
+        <li>@ccrc.gov.uk</li>
         </ul>
         <p><a class="govuk-link" href="#top">Back to top</a></p>
       </section>

--- a/source/user-guide.html.erb
+++ b/source/user-guide.html.erb
@@ -52,7 +52,7 @@ menuindex: 3
       </section>
       <section class="content-section content-section--with-top-border">
         <h2 id="feedback" class="govuk-heading-m">Give feedback</h2>
-        <p><a class="govuk-link" href="/contact/">Contact us by email or on Slack</a> to tell u s what you think of MoJ Forms and suggest improvements.</p>
+        <p><a class="govuk-link" href="/contact/">Contact us by email or on Slack</a> to tell us what you think of MoJ Forms and suggest improvements.</p>
         <p><a class="govuk-link" href="#top">Back to top</a></p>
       </section>
         <!-- END CONTENT -->


### PR DESCRIPTION
This PR changes the method for logging into ECR from the deploy script. Swapping using the long lived credentials to short lived ones.

Context: https://trello.com/c/nxKpb6g2