### PR TITLE
Update contact email address and correct link on home page

### DIFF
--- a/source/contact.html.erb
+++ b/source/contact.html.erb
@@ -22,7 +22,7 @@ menuindex: 4
             <h2>Support and feedback</h2>
               <p>For comments and questions about using MoJ Forms or for any technical problems:</p>
               <ul>
-              <li>email: <a class="govuk-link" href="mailto:moj-forms@digital.justice.gov.uk">moj-forms@digital.justice.gov.uk</a></li>
+              <li>email: <a class="govuk-link" href="mailto:contact-moj-forms@digital.justice.gov.uk">contact-moj-forms@digital.justice.gov.uk</a></li>
               <li>Slack: <a class="govuk-link" href="https://mojdt.slack.com/messages/CE26QEL1Z/">#ask-formbuilder on mojdt.slack.com</a></li>
               </ul>
               <p>When reporting a fault or bug, make sure to include:</p>

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -9,7 +9,7 @@ title: MoJ Forms
         <h1 class="hero__title">Publish digital forms quickly and easily</h1>
         <p class="hero__description">Give your users a secure, accessible way to contact you, make a request or submit information.</p>
         <p class="hero__description">If you work for the Ministry of Justice or one of its agencies, start building your own forms now.</p>
-        <a class="govuk-link" href="features" role="button" draggable="false" class="govuk-button govuk-button--start app-button--inverted" data-module="govuk-button" data-click-events data-click-category="Hero" data-click-action="Button clicked">
+        <a class="govuk-link" href="contact" role="button" draggable="false" class="govuk-button govuk-button--start app-button--inverted" data-module="govuk-button" data-click-events data-click-category="Hero" data-click-action="Button clicked">
           Contact MoJ Forms
           <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" role="presentation" focusable="false">
             <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
@@ -49,7 +49,7 @@ title: MoJ Forms
             <h2 class="govuk-heading-m">Cut the cost of building digital forms</h2>
             <p class="govuk-body">Design, build, publish and host any number of forms on your own for free.</p>
         </div>
-        <div class="govuk-grid-column-one-half">           
+        <div class="govuk-grid-column-one-half">
         <video width="470" controls poster="/images/flow_poster.jpg" style="border: 1px solid #CCC;" aria-label="Screen recording of the flow view of a form in MoJ Forms showing multiple branching points"><source src="/videos/mojf_flowview.mp4" type="video/mp4">Your browser does not support the video tag.</video>
       </div>
       </div>
@@ -79,7 +79,7 @@ title: MoJ Forms
         <li>HM Prisons and Probation Service (HMPPS) is enabling people to <a class="govuk-link" href="https://unwanted-prisoner-contact.form.service.justice.gov.uk/">block unwanted contact from prisoners</a></li>
         <li>MoJ recruitment team is connecting with people who are <a class="govuk-link" href="https://register-your-interest-in-prison-and-probation-jobs.form.service.justice.gov.uk/">interested in working in prisons and probation</a></li>
         <li>Criminal Injuries Compensation Authority (CICA) is capturing <a class="govuk-link" href="https://contact-the-cica.form.service.justice.gov.uk/">enquiries</a> and <a class="govuk-link" href="https://complain-to-the-cica.form.service.justice.gov.uk/">complaints</a> from the public</li>
-        </ul> 
+        </ul>
       </div>
     </div>
   </section>


### PR DESCRIPTION
Updates the contact email address on the contact page.

Also updates an incorrect link on the homepage, where the link text says 'contact us', but the link was to `/features`