### PR TITLE
Remove empty link

### DIFF
--- a/source/_cookie_banner.html.erb
+++ b/source/_cookie_banner.html.erb
@@ -38,7 +38,7 @@
 
     <div class="govuk-button-group">
       <button class="govuk-button" data-module="govuk-button" onclick="mojforms.cookiepolicy.hideCookieBanner()">
-        Hide this message
+        Hide cookie message
       </button>
     </div>
   </div>
@@ -56,7 +56,7 @@
 
     <div class="govuk-button-group">
       <button class="govuk-button" data-module="govuk-button" onclick="mojforms.cookiepolicy.hideCookieBanner()">
-        Hide this message
+        Hide cookie message
       </button>
     </div>
   </div>

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -19,7 +19,7 @@
     <%= partial 'analytics' %>
 
   </head>
-  <body class="govuk-template__body"><a id="top" href="#"></a>
+  <body id="top" class="govuk-template__body">
     <script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
 
     <%= partial 'cookie_banner' %>


### PR DESCRIPTION
This PR addresses two issues raised by our DAC accessibility audit.
* Presence of an empty link
* Button label unclear out of context

The layout contained an empty link tag used by the back-to-top functionality as it's anchor.  This shows up as an unlabelled control in a screenreader rotor.  Removed the link and moved the id onto the `body` element to retain the back-to-top functionality.

The button to dismiss the cookie banner had the label 'Hide this message' which for a screenreader browsing the site out of context (i.e. when reading a list of controls on the page) it is not clear what the button does.  Updated the copy to 'Hide cookie message'