### PR TITLE
Add same page hidden text to all TOC links

### DIFF
--- a/source/_toc.html.erb
+++ b/source/_toc.html.erb
@@ -1,0 +1,5 @@
+<ul class="govuk-list">
+  <% links.each do |link, text| %>
+    <li><a class="govuk-link" href="#<%=link%>"><%= text %><span class="govuk-visually-hidden">(same page)</span></a></li>
+  <% end %>
+</ul>

--- a/source/accessibility.html.erb
+++ b/source/accessibility.html.erb
@@ -15,9 +15,11 @@ order: 5
         <!-- START CONTENT -->
         <p class="govuk-body-l">How to ensure your form meets accessibility requirements and can be used by as many people as possible.</p>
         <h2 class="govuk-heading-m">Contents</h2>
-        <p><a class="govuk-link" href="#responsibilities">What you are responsible for</a><br>
-        <a class="govuk-link" href="#content">Ensuring your content is accessible</a><br>
-        <a class="govuk-link" href="#statement">Completing the accessibility statement</a></p>
+        <%= partial "toc", locals: { links: { 
+          'responsibilities': "What you are responsible for",
+          'content': "Ensuring your content is accessible",
+          'statement': "Completing the accessibility statement",
+         }} %>
       <section class="content-section content-section--with-top-border">
         
       

--- a/source/branching.html.erb
+++ b/source/branching.html.erb
@@ -15,13 +15,15 @@ order: 4
         <!-- START CONTENT -->
         <p class="govuk-body-l">Use advanced features to create and manage more complex forms.</p>
         <h2 class="govuk-heading-m">Contents</h2>
-        <p><a class="govuk-link" href="#branching">What is branching?</a><br>
-        <a class="govuk-link" href="#add-branching">Adding branching</a><br>
-        <a class="govuk-link" href="#edit-branching">Editing branching</a><br>
-        <a class="govuk-link" href="#delete-branching">Deleting branching</a><br>
-        <a class="govuk-link" href="#unconnected">What are unconnected pages?</a><br>
-        <a class="govuk-link" href="#reconnect-unconnected">Reconnecting unconnected pages</a><br>
-        <a class="govuk-link" href="#change-next-page">Changing the order of pages</a></p>
+        <%= partial "toc", locals: { links: { 
+          'branching': "What is branching?",
+          'add-branching': "Adding branching",
+          'edit-branching': "Editing branching",
+          'delete-branching': "Deleting branching",
+          'unconnected': "What are unconnected pages?",
+          'reconnect-unconnected': "Reconnecting unconnected pages",
+          'change-next-page': "Changing the order of pages",
+        }} %>
 
       <section class="content-section content-section--with-top-border">
         <h2 id="branching" class="govuk-heading-m">What is branching?</h2>

--- a/source/building-and-editing.html.erb
+++ b/source/building-and-editing.html.erb
@@ -15,24 +15,26 @@ order: 3
         <!-- START CONTENT -->
         <p class="govuk-body-l">Learn how to start building your first form.</p>
         <h2 class="govuk-heading-m">Contents</h2> 
-        <p><a class="govuk-link" href="#form-name">Naming your form</a><br>
-        <a class="govuk-link" href="#flow-view">Your initial view and pages</a><br>
-        <a class="govuk-link" href="#start-page">Choosing the right start page</a><br>
-        <a class="govuk-link" href="#footer">Footer pages</a><br>
-        <a class="govuk-link" href="#preview">Previewing your pages</a><br>
-        <a class="govuk-link" href="#adding-pages">Adding pages</a><br>
-        <a class="govuk-link" href="#moving-pages">Moving pages</a><br>
-        <a class="govuk-link" href="#editing-pages">Editing pages</a><br>
-        <a class="govuk-link" href="#deleting-pages">Deleting pages</a><br>
-        <a class="govuk-link" href="#page-type">Choosing the type of page</a><br>
-        <a class="govuk-link" href="#question-formats">Choosing which question format to use</a><br>
-        <a class="govuk-link" href="#autocomplete">Presenting users with a long list of options</a><br>
-        <a class="govuk-link" href="#file-upload">Asking users to submit a file</a><br>
-        <a class="govuk-link" href="#optional">Making a question optional</a><br>
-        <a class="govuk-link" href="#validation">Validating user answers</a><br>
-        <a class="govuk-link" href="#markdown">Formatting content with markdown</a><br>
-        <a class="govuk-link" href="#visibility">Targeting content with visibility</a><br>
-        <a class="govuk-link" href="#welsh-translation">Translating a form into Welsh</a></p>
+        <%= partial "toc", locals: { links: { 
+          'form-name': "Naming your form",
+          'flow-view': "Your initial view and pages",
+          'start-page': "Choosing the right start page",
+          'footer': "Footer pages",
+          'preview': "Previewing your pages",
+          'adding-pages': "Adding pages",
+          'moving-pages': "Moving pages",
+          'editing-pages': "Editing pages",
+          'deleting-pages': "Deleting pages",
+          'page-type': "Choosing the type of page",
+          'question-formats': "Choosing which question format to use",
+          'autocomplete': "Presenting users with a long list of options",
+          'file-upload': "Asking users to submit a file",
+          'optional': "Making a question optional",
+          'validation': "Validating user answers",
+          'markdown': "Formatting content with markdown",
+          'visibility': "Targeting content with visibility",
+          'welsh-translation': "Translating a form into Welsh",
+        }} %>
       <section class="content-section content-section--with-top-border">
         <h2 id="form-name" class="govuk-heading-m">Naming your form</h2>
         <p>When you create a new form, you need to give it a name.</p>

--- a/source/data-protection.html.erb
+++ b/source/data-protection.html.erb
@@ -15,12 +15,14 @@ order: 6
         <!-- START CONTENT -->
         <p class="govuk-body-l">How to ensure your form is compliant with data protection policies and procedures and keep your users’ data secure.</p>
         <h2 class="govuk-heading-m">Contents</h2>
-        <p><a class="govuk-link" href="#responsibilities">Your data protection responsibilities</a></br>
-        <a class="govuk-link" href="#registeractivity">Registering your data processing activity</a></br>
-        <a class="govuk-link" href="#designingtheform">Designing and building your form</a></br>
-        <a class="govuk-link" href="#privacynotice">Preparing a privacy notice</a></br>
-        <a class="govuk-link" href="#formsecurity">How your forms are secured</a></br>
-        <a class="govuk-link" href="#sessionduration">Session duration</a></p>
+        <%= partial "toc", locals: { links: { 
+          'responsibilities': "Your data protection responsibilities",
+          'registeractivity': "Registering your data processing activity",
+          'designingtheform': "Designing and building your form",
+          'privacynotice': "Preparing a privacy notice",
+          'formsecurity': "How your forms are secured",
+          'sessionduration': "Session duration",
+        }} %>
         <section class="content-section content-section--with-top-border">
         <h2 id="responsibilities" class="govuk-heading-m">Your data protection responsibilities</h2>
         <p>As you design a new form or make any substantial changes to an existing form, you will need to:</p>

--- a/source/getting-started.html.erb
+++ b/source/getting-started.html.erb
@@ -15,12 +15,14 @@ order: 2
         <!-- START CONTENT -->
         <p class="govuk-body-l">Everything you need to know about getting started with MoJ Forms and planning a form.</p>
         <h2 class="govuk-heading-m">Contents</h2>
-        <p><a class="govuk-link" href="#good-forms">What makes a good form</a></br>
-        <a class="govuk-link" href="#planning">Planning your form</a></br>
-        <a class="govuk-link" href="#security-classifications">Security classifications for your form</a></br>
-        <a class="govuk-link" href="#timescales">Timescales and engagement</a></br>
-        <a class="govuk-link" href="#assessment">Getting your form assessed</a></br>
-        <a class="govuk-link" href="#govuk">Getting on GOV.UK</a></p>
+        <%= partial "toc", locals: { links: { 
+          'good-forms': 'What makes a good form',
+          planning: 'Planning your form',
+          'security-classifications': 'Security classifications for your form',
+          timescales: 'Timescales and engagement',
+          assessment: 'Getting your form assessed',
+          govuk: 'Getting on GOV.UK',
+        }} %>
       <section class="content-section content-section--with-top-border">
           <h2 id="good-forms" class="govuk-heading-m">What makes a good form</h2>
         <p>Forms built with MoJ Forms should aim to meet the GOV.UK <a class="govuk-link" href="https://www.gov.uk/service-manual/service-standard">Service Standard</a>. This is a set of principles that helps government teams create and run high-quality services.</p> 

--- a/source/settings.html.erb
+++ b/source/settings.html.erb
@@ -15,14 +15,16 @@ order: 7
         <!-- START CONTENT -->
         <p class="govuk-body-l">Enable optional features such as save for later and Google Analytics and configure how you receive information when users submit their forms.</p>
         <h2 class="govuk-heading-m">Contents</h2>
-        <p><a class="govuk-link" href="#change-name">Changing your form's name and URL</a><br>
-        <a class="govuk-link" href="#google-analytics">Setting up Google Analytics</a><br>
-        <a class="govuk-link" href="#save-for-later">Enabling users to save their progress on a form</a><br>
-        <a class="govuk-link" href="#email-settings">Collecting information by email</a><br>
-        <a class="govuk-link" href="#confirmation-email">Sending users a confirmation email</a><br>
-        <a class="govuk-link" href="#references">Providing users with reference numbers</a><br>
-        <a class="govuk-link" href="#payment-links">Taking payments through GOV.UK Pay</a></br>
-        <a class="govuk-link" href="#transfer-form">Transferring your form to another user</a></p>
+        <%= partial "toc", locals: { links: { 
+'change-name': "Changing your form's name and URL",
+'google-analytics': "Setting up Google Analytics",
+'save-for-later': "Enabling users to save their progress on a form",
+'email-settings': "Collecting information by email",
+'confirmation-email': "Sending users a confirmation email",
+'references': "Providing users with reference numbers",
+'payment-links': "Taking payments through GOV.UK Pay",
+'transfer-form': "Transferring your form to another user",
+}} %>
         <section class="content-section content-section--with-top-border">
         <h2 id="change-name" class="govuk-heading-m">Changing your form's name and URL</h2>
         <p>You can review and update both your form's name and URL in settings. Go to: Settings > Form name and URL</p>

--- a/source/testing-and-publishing.html.erb
+++ b/source/testing-and-publishing.html.erb
@@ -15,14 +15,16 @@ order: 8
         <!-- START CONTENT -->
         <p class="govuk-body-l">How to test your form and share it securely with colleagues before publishing the final version.</p>
         <h2 class="govuk-heading-m">Contents</h2>
-        <p><a class="govuk-link" href="#publishing-process">Understanding the publishing process</a><br>
-        <a class="govuk-link" href="#before-publishing">Things to check before publishing</a><br>
-        <a class="govuk-link" href="#test">Publishing to Test</a><br>
-        <a class="govuk-link" href="#test-checks">What to look for when testing</a><br>
-        <a class="govuk-link" href="#final-check">Unlocking the ability to publish to Live</a><br>
-        <a class="govuk-link" href="#live">Publishing to Live</a></br>
-        <a class="govuk-link" href="#live-checks">What to check on Live</a></br>
-        <a class="govuk-link" href="#govuk">Getting your form on GOV.UK</a></p>
+        <%= partial "toc", locals: { links: { 
+          'publishing-process': "Understanding the publishing process",
+          'before-publishing': "Things to check before publishing",
+          'test': "Publishing to Test",
+          'test-checks': "What to look for when testing",
+          'final-check': "Unlocking the ability to publish to Live",
+          'live': "Publishing to Live",
+          'live-checks': "What to check on Live",
+          'govuk': "Getting your form on GOV.UK",
+        }} %>
         <section class="content-section content-section--with-top-border">
         <h2 id="publishing-process" class="govuk-heading-m">Understanding the publishing process</h2>
         <p>To see a fully working form that you can fill in and share with others, you have to publish it. MoJ Forms comes with both a Test site and Live site so that you can work on your form and only push changes live when you are happy with them. All changes made in the editor, including to settings, have to be published for them to take effect.<p>

--- a/source/user-guide.html.erb
+++ b/source/user-guide.html.erb
@@ -18,10 +18,12 @@ menuindex: 3
         <!-- START CONTENT -->
         <p class="govuk-body-l">Learn how to build, configure and publish forms and get help when you need it.</p>
         <h2 class="govuk-heading-m">Contents</h2>
-        <p><a class="govuk-link" href="#access">Getting access and signing in</a><br>
-        <a class="govuk-link" href="#issues">Known issues</a><br>
-        <a class="govuk-link" href="#help">Get help or report a bug</a><br>
-        <a class="govuk-link" href="#feedback">Give feedback</a></p>
+        <%= partial "toc", locals: { links: { 
+          'access': "Getting access and signing in",
+          'issues': "Known issues",
+          'help': "Get help or report a bug",
+          'feedback': "Give feedabck"
+        }} %>
       <section class="content-section content-section--with-top-border">
         <h2 id="access" class="govuk-heading-m">Getting access and signing in</h2>
         <p>MoJ Forms is only available to employees of MoJ and its agencies and public bodies. To request access, <a class="govuk-link" href="/contact">contact us</a> to discuss your requirements. As MoJ Forms is still in development, we need your consent to take part in ongoing research.</p>


### PR DESCRIPTION
This PR fixes an issue raised in our DAC audit regarding communicating the TOC links in the product page as being 'in-page' links, as some screenreaders don't announce this information.

As part of this I have also extracted the TOC into a partial (to ensure this is added to all links and to eliminate repetition)