### PR TITLE
Fix user guide nav issues

### DIFF
--- a/source/_user_nav.erb
+++ b/source/_user_nav.erb
@@ -1,10 +1,11 @@
   <nav class="sub-navigation">
+    <ul class="govuk-list">
   <% pages_by_category('user-guide').each do |page| %>
     <% if current_page.data.heading == page.data.heading %>
-    <p class="sub-navigation__item  sub-navigation__item--active "><%= page.data.heading %></p>
+    <li class="sub-navigation__item  sub-navigation__item--active "><%= page.data.heading %></li>
     <% else %>
-      <p class="sub-navigation__item "><%= link_to page.data.heading, page.url, class: 'govuk-link' %></p>
+      <li class="sub-navigation__item "><%= link_to page.data.heading, page.url, class: 'govuk-link' %></li>
     <% end %>
   <% end %>
-
+  </ul>
 </nav>

--- a/source/accessibility.html.erb
+++ b/source/accessibility.html.erb
@@ -3,77 +3,65 @@ title: Accessibility
 heading: Accessibility
 category: user-guide
 order: 5
+layout: user_guide
 ---
-<div class="govuk-width-container">
-  <main class="govuk-main-wrapper govuk-body" id="main-content" role="main">
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-one-quarter">
-        <%= partial "user_nav" %>
-      </div>
-      <div class="govuk-grid-column-three-quarters">
-        <h1 class="govuk-heading-l"><%= current_page.data.heading %></h1>
-        <!-- START CONTENT -->
-        <p class="govuk-body-l">How to ensure your form meets accessibility requirements and can be used by as many people as possible.</p>
-        <h2 class="govuk-heading-m">Contents</h2>
-        <%= partial "toc", locals: { links: { 
-          'responsibilities': "What you are responsible for",
-          'content': "Ensuring your content is accessible",
-          'statement': "Completing the accessibility statement",
-         }} %>
-      <section class="content-section content-section--with-top-border">
-        
-      
-      <h2 id="responsibilities" class="govuk-heading-m">What you are responsible for</h2>
-        <p>Any form you publish must meet <a class="govuk-link" href="https://www.gov.uk/guidance/accessibility-requirements-for-public-sector-websites-and-apps">government accessibility regulations</a>.</p>
-        <p>This means making sure it can be used by as many people as possible, including those with access needs.</p>
-        <p>It must be clear and simple enough so that most people can use it and work with a range of adaptive technologies such as screen readers and magnifiers.</p>
-        <p>MoJ Forms does most of the work to ensure that your form is accessible but you are responsible for:</p>
-        <ul>
-        <li>the <a class="govuk-link" href="#content">content of your form</a>, which includes things like headings, links and question text</li>
-        <li>completing and maintaining the <a class="govuk-link" href="#statement">accessibility statement</a></li>
-        </ul>
-        <p>If your form fails to meet government accessibility regulations, you may be found in breach of the Equality Act 2010 and the Disability Discrimination Act 1995. This could result in an investigation, unlawful act notices and court action.</p>
-        <p><a class="govuk-link" href="#top">Back to top</a></p>
-      </section>
-      <section class="content-section content-section--with-top-border">  
-      <h2 id="content" class="govuk-heading-m">Ensuring your content is accessible</h2>
-        <p>We have built MoJ Forms to produce accessible pages but the content needs to be accessible too.</p>
-        <p>Following these tips will help people understand and complete your form and ensure that it meets government standards.</p>
-        <p>The MoJ Digital Accessibility Team provides resources and training for anyone who wants to <a class="govuk-link" href="https://justiceuk.sharepoint.com/sites/knowthething/SitePages/Digital-Accessibility.aspx">learn more about creating accessible content and services</a>.</p>
-        <h3 class="govuk-heading-s">Give pages informative, unique titles</h3>
-        <p>The title helps users understand what the page is about.</p>
-        <p>On single question pages, the title is used for the question or instruction.</p>
-        <p>On a multi-question page or other page template, the title should describe the group of questions or subject of the page.</p>
-        <h3 class="govuk-heading-s">Use headings to convey meaning and structure</h3>
-        <p>MoJ Forms page templates already provide some structure using titles and questions.</p>
-        <p>When you add sections of information, such as on the home page and content pages, use headings for each section. Breaking content up in this way makes it easier for users to scan and find what they are looking for.</p>
-        <p>You can <a class="govuk-link" href="/building-and-editing/#markdown">format your headings using markdown</a>. This is a quick and simple way to apply styles to your content.</p>
-        <p>Headings should be formatted and ordered by level. The page title is always level 1 so any headings you add should start with level 2 and be nested as necessary. GOV.UK includes more guidance on using headings properly under <a class="govuk-link" href="https://www.gov.uk/guidance/content-design/writing-for-gov-uk#headings">structuring your content</a>.</p>
-        <p>Don't use headings just to make text look bigger or stand out - there are other markdown options for that, such as <a class="govuk-link" href="/building-and-editing/#markdown">bold, call to action and inset text</a>.</p>
-        <h3 class="govuk-heading-s">Make link text meaningful</h3>
-        <p>You can use markdown to <a class="govuk-link" href="/building-and-editing/#markdown">add links to other web pages</a>, for example to a GOV.UK guidance page or related publication.</p>
-        <p>The link text should describe the content of the page you are linking to. Avoid vague terms like 'click here' and 'read more' and don't use the same words for different links on a page.</p>
-        <p>Try not to use links in the middle of a form as the user may lose their progress if they leave the form.</p>
-        <h3 class="govuk-heading-s">Provide clear instructions</h3>
-        <p>Help users understand what they need to do and what information you are asking for with clear instructions.</p>
-        <p>For example, include hint text to help users understand what information you need from a question or how it should be formatted. If you apply any optional <a class="govuk-link" href="/building-and-editing/#validation">validation criteria</a>, you should also explain these in the hint text.</p>
-        <p>MoJ Forms automatically generates error messages where needed.</p>
-        <h3 class="govuk-heading-s">Keep content clear and concise</h3>
-        <p>Use short and direct questions and avoid complex or technical terminology.</p>
-        <p>Follow the <a class="govuk-link" href="https://www.gov.uk/guidance/content-design/writing-for-gov-uk">GOV.UK guidance on writing for the web</a> and the <a class="govuk-link" href="https://www.gov.uk/service-manual/design/designing-good-questions">Service Manual guidance on designing good questions</a>.
-        <p><a class="govuk-link" href="#top">Back to top</a></p>
-      </section>
-      <section class="content-section content-section--with-top-border">
-    <h2 id="statement" class="govuk-heading-m">Completing the accessibility statement</h2>
-          <p>All forms are created with an accessibility page in the <a class="govuk-link" href="/building-and-editing/#footer">footer section</a> which comes pre-populated with a template accessibility statement.
-          <p>There are sections in the statement that you must fill in with details specific to your team and form. These are indicated in square brackets - [like this].</p>
-          <p>If you are updating an existing form, you will need to check your accessibility statement against the latest version of the template as some sections may have changed.</p>
-          <p>We recommend that you review and update your statement at least once a year to ensure it remains current.</p>
-          <p><a class="govuk-link" href="/accessibility-statement-template">Accessibility statement - template</p>
-          <p><a class="govuk-link" href="#top">Back to top</a></p>
-        </section>
-        <!-- END CONTENT -->
-      </div>
-    </div>
-  </main>
-</div>
+
+<h1 class="govuk-heading-l"><%= current_page.data.heading %></h1>
+<p class="govuk-body-l">How to ensure your form meets accessibility requirements and can be used by as many people as possible.</p>
+<h2 class="govuk-heading-m">Contents</h2>
+<%= partial "toc", locals: { links: { 
+  'responsibilities': "What you are responsible for",
+  'content': "Ensuring your content is accessible",
+  'statement': "Completing the accessibility statement",
+ }} %>
+<section class="content-section content-section--with-top-border">
+  <h2 id="responsibilities" class="govuk-heading-m">What you are responsible for</h2>
+  <p>Any form you publish must meet <a class="govuk-link" href="https://www.gov.uk/guidance/accessibility-requirements-for-public-sector-websites-and-apps">government accessibility regulations</a>.</p>
+  <p>This means making sure it can be used by as many people as possible, including those with access needs.</p>
+  <p>It must be clear and simple enough so that most people can use it and work with a range of adaptive technologies such as screen readers and magnifiers.</p>
+  <p>MoJ Forms does most of the work to ensure that your form is accessible but you are responsible for:</p>
+  <ul>
+    <li>completing and maintaining the <a class="govuk-link" href="#statement">accessibility statement</a></li>
+    <li>the <a class="govuk-link" href="#content">content of your form</a>, which includes things like headings, links and question text</li>
+  </ul>
+  <p>If your form fails to meet government accessibility regulations, you may be found in breach of the Equality Act 2010 and the Disability Discrimination Act 1995. This could result in an investigation, unlawful act notices and court action.</p>
+  <p><a class="govuk-link" href="#top">Back to top</a></p>
+</section>
+<section class="content-section content-section--with-top-border">  
+  <h2 id="content" class="govuk-heading-m">Ensuring your content is accessible</h2>
+  <p>We have built MoJ Forms to produce accessible pages but the content needs to be accessible too.</p>
+  <p>Following these tips will help people understand and complete your form and ensure that it meets government standards.</p>
+  <p>The MoJ Digital Accessibility Team provides resources and training for anyone who wants to <a class="govuk-link" href="https://justiceuk.sharepoint.com/sites/knowthething/SitePages/Digital-Accessibility.aspx">learn more about creating accessible content and services</a>.</p>
+  <h3 class="govuk-heading-s">Give pages informative, unique titles</h3>
+  <p>The title helps users understand what the page is about.</p>
+  <p>On single question pages, the title is used for the question or instruction.</p>
+  <p>On a multi-question page or other page template, the title should describe the group of questions or subject of the page.</p>
+  <h3 class="govuk-heading-s">Use headings to convey meaning and structure</h3>
+  <p>MoJ Forms page templates already provide some structure using titles and questions.</p>
+  <p>When you add sections of information, such as on the home page and content pages, use headings for each section. Breaking content up in this way makes it easier for users to scan and find what they are looking for.</p>
+  <p>You can <a class="govuk-link" href="/building-and-editing/#markdown">format your headings using markdown</a>. This is a quick and simple way to apply styles to your content.</p>
+  <p>Headings should be formatted and ordered by level. The page title is always level 1 so any headings you add should start with level 2 and be nested as necessary. GOV.UK includes more guidance on using headings properly under <a class="govuk-link" href="https://www.gov.uk/guidance/content-design/writing-for-gov-uk#headings">structuring your content</a>.</p>
+  <p>Don't use headings just to make text look bigger or stand out - there are other markdown options for that, such as <a class="govuk-link" href="/building-and-editing/#markdown">bold, call to action and inset text</a>.</p>
+  <h3 class="govuk-heading-s">Make link text meaningful</h3>
+  <p>You can use markdown to <a class="govuk-link" href="/building-and-editing/#markdown">add links to other web pages</a>, for example to a GOV.UK guidance page or related publication.</p>
+  <p>The link text should describe the content of the page you are linking to. Avoid vague terms like 'click here' and 'read more' and don't use the same words for different links on a page.</p>
+  <p>Try not to use links in the middle of a form as the user may lose their progress if they leave the form.</p>
+  <h3 class="govuk-heading-s">Provide clear instructions</h3>
+  <p>Help users understand what they need to do and what information you are asking for with clear instructions.</p>
+  <p>For example, include hint text to help users understand what information you need from a question or how it should be formatted. If you apply any optional <a class="govuk-link" href="/building-and-editing/#validation">validation criteria</a>, you should also explain these in the hint text.</p>
+  <p>MoJ Forms automatically generates error messages where needed.</p>
+  <h3 class="govuk-heading-s">Keep content clear and concise</h3>
+  <p>Use short and direct questions and avoid complex or technical terminology.</p>
+  <p>Follow the <a class="govuk-link" href="https://www.gov.uk/guidance/content-design/writing-for-gov-uk">GOV.UK guidance on writing for the web</a> and the <a class="govuk-link" href="https://www.gov.uk/service-manual/design/designing-good-questions">Service Manual guidance on designing good questions</a>.
+  <p><a class="govuk-link" href="#top">Back to top</a></p>
+</section>
+<section class="content-section content-section--with-top-border">
+  <h2 id="statement" class="govuk-heading-m">Completing the accessibility statement</h2>
+  <p>All forms are created with an accessibility page in the <a class="govuk-link" href="/building-and-editing/#footer">footer section</a> which comes pre-populated with a template accessibility statement.
+  <p>There are sections in the statement that you must fill in with details specific to your team and form. These are indicated in square brackets - [like this].</p>
+  <p>If you are updating an existing form, you will need to check your accessibility statement against the latest version of the template as some sections may have changed.</p>
+  <p>We recommend that you review and update your statement at least once a year to ensure it remains current.</p>
+  <p><a class="govuk-link" href="/accessibility-statement-template">Accessibility statement - template</p>
+  <p><a class="govuk-link" href="#top">Back to top</a></p>
+  </section>
+

--- a/source/branching.html.erb
+++ b/source/branching.html.erb
@@ -3,154 +3,143 @@ title: Branching and flow management
 heading: Branching and flow management
 category: user-guide
 order: 4
+layout: user_guide
 ---
-<div class="govuk-width-container">
-  <main class="govuk-main-wrapper govuk-body" id="main-content" role="main">
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-one-quarter">
-        <%= partial "user_nav" %>
-      </div>
-      <div class="govuk-grid-column-three-quarters">
-        <h1 class="govuk-heading-l"><%= current_page.data.heading %></h1>
-        <!-- START CONTENT -->
-        <p class="govuk-body-l">Use advanced features to create and manage more complex forms.</p>
-        <h2 class="govuk-heading-m">Contents</h2>
-        <%= partial "toc", locals: { links: { 
-          'branching': "What is branching?",
-          'add-branching': "Adding branching",
-          'edit-branching': "Editing branching",
-          'delete-branching': "Deleting branching",
-          'unconnected': "What are unconnected pages?",
-          'reconnect-unconnected': "Reconnecting unconnected pages",
-          'change-next-page': "Changing the order of pages",
-        }} %>
+<h1 class="govuk-heading-l"><%= current_page.data.heading %></h1>
+<p class="govuk-body-l">Use advanced features to create and manage more complex forms.</p>
+<h2 class="govuk-heading-m">Contents</h2>
+<%= partial "toc", locals: { links: { 
+  'branching': "What is branching?",
+  'add-branching': "Adding branching",
+  'edit-branching': "Editing branching",
+  'delete-branching': "Deleting branching",
+  'unconnected': "What are unconnected pages?",
+  'reconnect-unconnected': "Reconnecting unconnected pages",
+  'change-next-page': "Changing the order of pages",
+}} %>
 
-      <section class="content-section content-section--with-top-border">
-        <h2 id="branching" class="govuk-heading-m">What is branching?</h2>
-        <p>Branching is what we call the ability to show users different pages based on their previous answers. You can create multiple routes - branches - through your form so that the people filling it in see only the questions or content that are relevant to them. With branching, a form can be quicker and easier to fill in and the answers given can be more relevant to your needs.</p>
-        <p>With MoJ Forms, branching can be set up in minutes without any specialist knowledge of coding or logic. The branches are clearly shown in the form flow view.</p>
-        <img src="/images/branches-on-flow-view.png" alt="The branches of a form are indicated in the flow view by arrows." class="screenshot-image">
-        <p>Branching requires 2 things:</p>
-        <ul>
-        <li>a radio button or checkbox question to base the branching on - these are the only question types that currently support branching</li>
-        <li>a destination page for each of the branches you want to create</li>
-        </ul>
-        <p>It's not currently possible to set conditions at a component level on a single page. So, for example, if you wanted to change only one thing on a page for different users, you would need to create 2 versions of that page on different branches.</p>
-        <p><a class="govuk-link" href="#top">Back to top</a></p>
-      </section>
+<section class="content-section content-section--with-top-border">
+<h2 id="branching" class="govuk-heading-m">What is branching?</h2>
+<p>Branching is what we call the ability to show users different pages based on their previous answers. You can create multiple routes - branches - through your form so that the people filling it in see only the questions or content that are relevant to them. With branching, a form can be quicker and easier to fill in and the answers given can be more relevant to your needs.</p>
+<p>With MoJ Forms, branching can be set up in minutes without any specialist knowledge of coding or logic. The branches are clearly shown in the form flow view.</p>
+<img src="/images/branches-on-flow-view.png" alt="The branches of a form are indicated in the flow view by arrows." class="screenshot-image">
+<p>Branching requires 2 things:</p>
+<ul>
+  <li>a radio button or checkbox question to base the branching on - these are the only question types that currently support branching</li>
+  <li>a destination page for each of the branches you want to create</li>
+</ul>
+<p>It's not currently possible to set conditions at a component level on a single page. So, for example, if you wanted to change only one thing on a page for different users, you would need to create 2 versions of that page on different branches.</p>
+<p><a class="govuk-link" href="#top">Back to top</a></p>
+</section>
 
-      <section class="content-section content-section--with-top-border">
-        <h2 id="add-branching" class="govuk-heading-m">Adding branching</h2>
-        <p>To add branching, open the connection menu (+) at the point where you want your form to branch and select 'Add branching'. This will create a 'branching point' - a page where you configure the rules for your branches.</p>
-        <p>Before you add branching, consider 2 things:</p>
-        <ol>
-        <li>What questions are you basing your branching on? Your form should contain at least one radio button or checkbox question for this. You can use a single question or combine multiple questions to create as many branches as you need.</li>
-        <li>What pages will your branches lead to? You can create these pages first or point all your branches to the same page (for example, the check answers page) and add extra pages later. If you intend any of your branches to end in an <a class="govuk-link" href="/building-and-editing/#page-type">exit page</a> - for example, to disqualify certain users from progressing through the form - it's easier to do this after setting up the branching point.</li>
-        </ol>
-        <p>Don't worry if you haven't worked out all the details of your branches up front. It's easy to change and expand your branches as you go.</p>
-        <h3 class="govuk-heading-s">Configuring the branching point</h3>
-        <p>A branching point contains 2 blank branches by default - 'branch 1' and 'otherwise'. You can add as many branches as you need using the 'add another branch' option.</p>
-        <p>Forms apply branching rules from top to bottom. A user will be routed along the first branch they meet the conditions for, even if they also meet the conditions of other branches. You can't change the order of branches so you may need to play around with your settings to get them right.</p>
-        <img src="/images/branching-point-form.png" alt="A branching point captures the page that the branch will lead to and the condition that must be met for a user to be routed along the branch." class="screenshot-image">
-        <p>Each branch form (indicated by branch 1, branch 2 and so on) allows you to specify the rules of a branch. These consist of:<p>
-        <ul>
-        <li>If - the condition that must be met for a user to be routed along the branch</li>
-        <li>Go to - the page that the branch will lead to</li>
-        </ul>
-        <p>There are several elements to a condition. The options will vary depending on whether you are using a radio button or checkbox question but they generally include:</p>
-        <ul>
-        <li>the question</li>
-        <li>an operator - such as 'is' or 'is not'</li>
-        <li>the user's answer</li>
-        </ul>
-        <p>The options for operator and answer will only appear after you have selected a question.</p>
-        <p>For example, a condition could be if the answer to a question about your favourite colour <strong>is</strong> red or <strong>is not</strong> blue or <strong>contains</strong> orange.</p>
-        <p>A branch can have as many conditions as you need but all must be met for the user to be routed along the branch.</p>
-        <h3 class="govuk-heading-s">The 'otherwise' branch</h3>
-        <p>The 'otherwise' branch is a final branch to capture any users that don't meet the conditions of your other branches. It is set to the next page in the flow when the branching point is first created but can be changed to another page.</p>
-        <p>This final branch can't be deleted so it's helpful to consider it when planning your form. For example, if you know that there are only 2 possible routes for your users (such as with a 'yes' or 'no' question), you only need to define a branch for one of those routes and allow other users to route along the 'otherwise' branch.</p>
-        <h3 class="govuk-heading-s">Adjusting the flow view</h3>
-        <p>After saving your branching point, your new branches will be reflected in the flow view. Your pages will be rearranged and new arrows drawn to indicate the paths a user could take when completing your form. You may need to make some adjustments at this point for a few reasons:
-        <ol>
-        <li>If you chose to point all of your branches to the same page, you can now start adding pages to build out your branches.</li>
-        <li>If you created the pages you wanted your branches to lead to first, they will still be linked to each other. This may or may not be correct for your form.</li>
-        <li>Any pages that were between the branching point and the 'go to' page of a particular branch when you set up the branching point will become unconnected and be moved to the unconnected pages section (see <a class="govuk-link" href="#unconnected">What are unconnected pages?</a> for details).</li>
-        </ol>
-        <p>These issues can be fixed quickly and easily. See <a class="govuk-link" href="#change-next-page">Changing the order of pages</a> for details.</p>
-        <p><a class="govuk-link" href="#top">Back to top</a></p>
-      </section>
-      <section class="content-section content-section--with-top-border">
-        <h2 id="edit-branching" class="govuk-heading-m">Editing branching</h2>
-        <p>You can open a branching point to edit in 2 ways:</p>
-        <ul>
-        <li>clicking directly on the branching point diamond</li>
-        <li>hovering over the diamond to reveal the branching point menu (3 dots in a circle) and selecting 'edit branching'</li>
-        </ul>
-        <p><a class="govuk-link" href="#top">Back to top</a></p>
-      </section>
-      <section class="content-section content-section--with-top-border">
-        <h2 id="delete-branching" class="govuk-heading-m">Deleting branching</h2>
-        <p>You can delete individual branches or the entire branching point:</p>
-        <ul>
-        <li>individual branches can be deleted in the branching point page from the branch menu in the top right corner of each branch</li>
-        <li>branching points can be deleted in form flow view from the branching point menu revealed when you mouse over the diamond</li>
-        </ul>
-        <p>When you delete a branching point, you are able to select which branch you want to retain as your main path.</p>
-        <p>Any pages no longer linked in your form flow after the deletion will be moved to the unconnected pages section.</p>
-        <p>Deleting a branch or branching point is permanent and cannot be undone.</p>
-        <p><a class="govuk-link" href="#top">Back to top</a></p>
-      </section>
-      <section class="content-section content-section--with-top-border">
-        <h2 id="unconnected" class="govuk-heading-m">What are unconnected pages?</h2>
-        <p>Unconnected pages are pages that have no other pages leading to them. When this happens, they become detached from your main form flow and stored in a separate section.</p>
-        <p>Pages (and branching points) may become unconnected in a number of ways:</p>
-        <ul>
-        <li>when you create a branch and set the 'go to' page, any pages between the branching point and the 'go to' page may become unconnected</li>
-        <li>when you use 'change next page' to change the order of your pages in the flow, any pages that are bypassed by the new flow may become unconnected</li>
-        <li>when you add an exit page, any pages that come after the new page may become unconnected</li>
-        </ul>
-        </p>
-        <p<You can edit, preview and delete unconnected pages as you would any other page in your form. To do so, hover over the thumbnail to reveal the page menu (3 dots in a circle).</p>
-        <p>Unconnected pages will be published with the rest of your form but remain invisible to users. They can only be accessed by someone with the specific page URL.</p>
-        <p><a class="govuk-link" href="#top">Back to top</a></p>
-      </section>
-      <section class="content-section content-section--with-top-border">
-        <h2 id="reconnect-unconnected" class="govuk-heading-m">Reconnecting unconnected pages</h2>
-        <p>Unconnected pages can be brought back into your main form in a number of ways.</p>
-        <p>In most cases, the easiest ways is with <a class="govuk-link" href="/building-and-editing/#moving-pages">'move page'</a> - this option allows you to move one page at a time to anywhere in the flow. To move an unconected page, hover over the thumbnail to open the page menu (3 dots in a circle) and select 'move page'.</p>
-        <p>A group of unconnected pages can be brought back into your main flow in one go from the point where you'd like to insert them:</p>
-        <ul>
-        <li>immediately after a branching point - by editing the branching point to set the first page as the 'go to' page</li>
-        <li>after another page - by using 'change next page' in the connection menu (+) to set the first page as the next page</li>
-        </ul>
-        <p>The group of unconnected pages will all be moved back into your main form together.</p>
-        <p>See <a class="govuk-link" href="#change-next-page">Changing the order of pages</a> for details.</p>
-        <p><a class="govuk-link" href="#top">Back to top</a></p>
-      </section>
-      <section class="content-section content-section--with-top-border">
-        <h2 id="change-next-page" class="govuk-heading-m">Changing the order of pages</h2>
-        <p>'Change next page' allows you to change which page comes next in the flow from any point. The 'go to' setting in a branching point has the same effect.</p>
-        <p>These options allow you to change the order of your pages in the flow by pointing arrows at different pages. They are also how you bring pages back from the unconnected pages section into the main flow.</p>
-        <p>For example, if you had 5 pages like this:</p>
-        <img src="/images/changing-order-1.png" alt="5 pages are arranged in order and numbered 1 to 5." class="screenshot-image">
-        <p>You could change the next page after page 2 to be page 4, like this:</p>
-        <img src="/images/changing-order-2.png" alt="When the destination of page 2 is changed to page 4, page 3 becomes unconnected." class="screenshot-image">
-        <p>Any pages between the current next page and the new next page - such as page 3, in this example - become unconnected. This means there is no possible path to them anymore and they are moved to a separate unconnected pages section below your main flow.</p>
-        <p>You can bring unconnected pages back into the flow by changing the next page of one of the pages in the flow. For example, you could change the next page after page 4 to be page 3, like this:</p>
-        <img src="/images/changing-order-3.png" alt="When the destination of page 4 is changed to page 3, page 5 becomes unconnected. Page 3 leads back to page 4, creating a loop." class="screenshot-image">
-        <p>Unconnected pages 'remember' their next page so when you bring them back into your form flow other pages may be moved as a result. In this example, page 3 still leads to page 4, which has caused a loop. Page 5 has become unconnected. To fix it, simply change page 3's next page, like this:</p>
-        <img src="/images/changing-order-4.png" alt="Pages 1 to 5 are now shown rearranged in order of 1, 2, 4, 3 and 5." class="screenshot-image">
-        <p>If the unconnected page you select is connected to other pages, these will also be brought back into the main flow in the same order.</p>
-        <p>Editing the 'go to' setting in the branching point works in the same way and points the branch's first arrow at your selected page.</p>
-        <h3 class="govuk-heading-s">Undoing change next page</h3>
-        <p>When you use change next page, an undo button will appear alongside the preview button. Clicking this button will reverse the change.</p>
-        <p>If you undo the change, a redo button will appear allowing you to repeat the original action.</p>
-        <p>If you perform any other action on your form, the button will disappear and you will no longer be able to undo or redo the action.</p>
-        <img src="/images/undo-change-next-page.png" alt="Screengrab showing the MoJ Forms flow view. A button labelled Undo change next page is visible alongside the Preview button." class="screenshot-image">        
-        <p><a class="govuk-link" href="#top">Back to top</a></p>
-      </section>
-        <!-- END CONTENT -->
-      </div>
-    </div>
-  </main>
-</div>
+<section class="content-section content-section--with-top-border">
+  <h2 id="add-branching" class="govuk-heading-m">Adding branching</h2>
+  <p>To add branching, open the connection menu (+) at the point where you want your form to branch and select 'Add branching'. This will create a 'branching point' - a page where you configure the rules for your branches.</p>
+  <p>Before you add branching, consider 2 things:</p>
+  <ol>
+    <li>What questions are you basing your branching on? Your form should contain at least one radio button or checkbox question for this. You can use a single question or combine multiple questions to create as many branches as you need.</li>
+    <li>What pages will your branches lead to? You can create these pages first or point all your branches to the same page (for example, the check answers page) and add extra pages later. If you intend any of your branches to end in an <a class="govuk-link" href="/building-and-editing/#page-type">exit page</a> - for example, to disqualify certain users from progressing through the form - it's easier to do this after setting up the branching point.</li>
+  </ol>
+  <p>Don't worry if you haven't worked out all the details of your branches up front. It's easy to change and expand your branches as you go.</p>
+  <h3 class="govuk-heading-s">Configuring the branching point</h3>
+  <p>A branching point contains 2 blank branches by default - 'branch 1' and 'otherwise'. You can add as many branches as you need using the 'add another branch' option.</p>
+  <p>Forms apply branching rules from top to bottom. A user will be routed along the first branch they meet the conditions for, even if they also meet the conditions of other branches. You can't change the order of branches so you may need to play around with your settings to get them right.</p>
+  <img src="/images/branching-point-form.png" alt="A branching point captures the page that the branch will lead to and the condition that must be met for a user to be routed along the branch." class="screenshot-image">
+  <p>Each branch form (indicated by branch 1, branch 2 and so on) allows you to specify the rules of a branch. These consist of:<p>
+  <ul>
+    <li>If - the condition that must be met for a user to be routed along the branch</li>
+    <li>Go to - the page that the branch will lead to</li>
+  </ul>
+  <p>There are several elements to a condition. The options will vary depending on whether you are using a radio button or checkbox question but they generally include:</p>
+  <ul>
+    <li>the question</li>
+    <li>an operator - such as 'is' or 'is not'</li>
+    <li>the user's answer</li>
+  </ul>
+  <p>The options for operator and answer will only appear after you have selected a question.</p>
+  <p>For example, a condition could be if the answer to a question about your favourite colour <strong>is</strong> red or <strong>is not</strong> blue or <strong>contains</strong> orange.</p>
+  <p>A branch can have as many conditions as you need but all must be met for the user to be routed along the branch.</p>
+  <h3 class="govuk-heading-s">The 'otherwise' branch</h3>
+  <p>The 'otherwise' branch is a final branch to capture any users that don't meet the conditions of your other branches. It is set to the next page in the flow when the branching point is first created but can be changed to another page.</p>
+  <p>This final branch can't be deleted so it's helpful to consider it when planning your form. For example, if you know that there are only 2 possible routes for your users (such as with a 'yes' or 'no' question), you only need to define a branch for one of those routes and allow other users to route along the 'otherwise' branch.</p>
+  <h3 class="govuk-heading-s">Adjusting the flow view</h3>
+  <p>After saving your branching point, your new branches will be reflected in the flow view. Your pages will be rearranged and new arrows drawn to indicate the paths a user could take when completing your form. You may need to make some adjustments at this point for a few reasons:
+  <ol>
+    <li>If you chose to point all of your branches to the same page, you can now start adding pages to build out your branches.</li>
+    <li>If you created the pages you wanted your branches to lead to first, they will still be linked to each other. This may or may not be correct for your form.</li>
+    <li>Any pages that were between the branching point and the 'go to' page of a particular branch when you set up the branching point will become unconnected and be moved to the unconnected pages section (see <a class="govuk-link" href="#unconnected">What are unconnected pages?</a> for details).</li>
+  </ol>
+  <p>These issues can be fixed quickly and easily. See <a class="govuk-link" href="#change-next-page">Changing the order of pages</a> for details.</p>
+  <p><a class="govuk-link" href="#top">Back to top</a></p>
+</section>
+<section class="content-section content-section--with-top-border">
+  <h2 id="edit-branching" class="govuk-heading-m">Editing branching</h2>
+  <p>You can open a branching point to edit in 2 ways:</p>
+  <ul>
+    <li>clicking directly on the branching point diamond</li>
+    <li>hovering over the diamond to reveal the branching point menu (3 dots in a circle) and selecting 'edit branching'</li>
+  </ul>
+  <p><a class="govuk-link" href="#top">Back to top</a></p>
+</section>
+<section class="content-section content-section--with-top-border">
+  <h2 id="delete-branching" class="govuk-heading-m">Deleting branching</h2>
+  <p>You can delete individual branches or the entire branching point:</p>
+  <ul>
+    <li>individual branches can be deleted in the branching point page from the branch menu in the top right corner of each branch</li>
+    <li>branching points can be deleted in form flow view from the branching point menu revealed when you mouse over the diamond</li>
+  </ul>
+  <p>When you delete a branching point, you are able to select which branch you want to retain as your main path.</p>
+  <p>Any pages no longer linked in your form flow after the deletion will be moved to the unconnected pages section.</p>
+  <p>Deleting a branch or branching point is permanent and cannot be undone.</p>
+  <p><a class="govuk-link" href="#top">Back to top</a></p>
+</section>
+<section class="content-section content-section--with-top-border">
+  <h2 id="unconnected" class="govuk-heading-m">What are unconnected pages?</h2>
+  <p>Unconnected pages are pages that have no other pages leading to them. When this happens, they become detached from your main form flow and stored in a separate section.</p>
+  <p>Pages (and branching points) may become unconnected in a number of ways:</p>
+  <ul>
+    <li>when you create a branch and set the 'go to' page, any pages between the branching point and the 'go to' page may become unconnected</li>
+    <li>when you use 'change next page' to change the order of your pages in the flow, any pages that are bypassed by the new flow may become unconnected</li>
+    <li>when you add an exit page, any pages that come after the new page may become unconnected</li>
+  </ul>
+  </p>
+  <p<You can edit, preview and delete unconnected pages as you would any other page in your form. To do so, hover over the thumbnail to reveal the page menu (3 dots in a circle).</p>
+  <p>Unconnected pages will be published with the rest of your form but remain invisible to users. They can only be accessed by someone with the specific page URL.</p>
+  <p><a class="govuk-link" href="#top">Back to top</a></p>
+</section>
+<section class="content-section content-section--with-top-border">
+  <h2 id="reconnect-unconnected" class="govuk-heading-m">Reconnecting unconnected pages</h2>
+  <p>Unconnected pages can be brought back into your main form in a number of ways.</p>
+  <p>In most cases, the easiest ways is with <a class="govuk-link" href="/building-and-editing/#moving-pages">'move page'</a> - this option allows you to move one page at a time to anywhere in the flow. To move an unconected page, hover over the thumbnail to open the page menu (3 dots in a circle) and select 'move page'.</p>
+  <p>A group of unconnected pages can be brought back into your main flow in one go from the point where you'd like to insert them:</p>
+  <ul>
+    <li>immediately after a branching point - by editing the branching point to set the first page as the 'go to' page</li>
+    <li>after another page - by using 'change next page' in the connection menu (+) to set the first page as the next page</li>
+  </ul>
+  <p>The group of unconnected pages will all be moved back into your main form together.</p>
+  <p>See <a class="govuk-link" href="#change-next-page">Changing the order of pages</a> for details.</p>
+  <p><a class="govuk-link" href="#top">Back to top</a></p>
+</section>
+<section class="content-section content-section--with-top-border">
+  <h2 id="change-next-page" class="govuk-heading-m">Changing the order of pages</h2>
+  <p>'Change next page' allows you to change which page comes next in the flow from any point. The 'go to' setting in a branching point has the same effect.</p>
+  <p>These options allow you to change the order of your pages in the flow by pointing arrows at different pages. They are also how you bring pages back from the unconnected pages section into the main flow.</p>
+  <p>For example, if you had 5 pages like this:</p>
+  <img src="/images/changing-order-1.png" alt="5 pages are arranged in order and numbered 1 to 5." class="screenshot-image">
+  <p>You could change the next page after page 2 to be page 4, like this:</p>
+  <img src="/images/changing-order-2.png" alt="When the destination of page 2 is changed to page 4, page 3 becomes unconnected." class="screenshot-image">
+  <p>Any pages between the current next page and the new next page - such as page 3, in this example - become unconnected. This means there is no possible path to them anymore and they are moved to a separate unconnected pages section below your main flow.</p>
+  <p>You can bring unconnected pages back into the flow by changing the next page of one of the pages in the flow. For example, you could change the next page after page 4 to be page 3, like this:</p>
+  <img src="/images/changing-order-3.png" alt="When the destination of page 4 is changed to page 3, page 5 becomes unconnected. Page 3 leads back to page 4, creating a loop." class="screenshot-image">
+  <p>Unconnected pages 'remember' their next page so when you bring them back into your form flow other pages may be moved as a result. In this example, page 3 still leads to page 4, which has caused a loop. Page 5 has become unconnected. To fix it, simply change page 3's next page, like this:</p>
+  <img src="/images/changing-order-4.png" alt="Pages 1 to 5 are now shown rearranged in order of 1, 2, 4, 3 and 5." class="screenshot-image">
+  <p>If the unconnected page you select is connected to other pages, these will also be brought back into the main flow in the same order.</p>
+  <p>Editing the 'go to' setting in the branching point works in the same way and points the branch's first arrow at your selected page.</p>
+  <h3 class="govuk-heading-s">Undoing change next page</h3>
+  <p>When you use change next page, an undo button will appear alongside the preview button. Clicking this button will reverse the change.</p>
+  <p>If you undo the change, a redo button will appear allowing you to repeat the original action.</p>
+  <p>If you perform any other action on your form, the button will disappear and you will no longer be able to undo or redo the action.</p>
+  <img src="/images/undo-change-next-page.png" alt="Screengrab showing the MoJ Forms flow view. A button labelled Undo change next page is visible alongside the Preview button." class="screenshot-image">        
+  <p><a class="govuk-link" href="#top">Back to top</a></p>
+</section>
+

--- a/source/building-and-editing.html.erb
+++ b/source/building-and-editing.html.erb
@@ -3,120 +3,114 @@ title: Building and editing
 heading: Building and editing
 category: user-guide
 order: 3
+layout: user_guide
 ---
-<div class="govuk-width-container">
-  <main class="govuk-main-wrapper govuk-body" id="main-content" role="main">
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-one-quarter">
-        <%= partial "user_nav" %>
-      </div>
-      <div class="govuk-grid-column-three-quarters">
-        <h1 class="govuk-heading-l"><%= current_page.data.heading %></h1>
-        <!-- START CONTENT -->
-        <p class="govuk-body-l">Learn how to start building your first form.</p>
-        <h2 class="govuk-heading-m">Contents</h2> 
-        <%= partial "toc", locals: { links: { 
-          'form-name': "Naming your form",
-          'flow-view': "Your initial view and pages",
-          'start-page': "Choosing the right start page",
-          'footer': "Footer pages",
-          'preview': "Previewing your pages",
-          'adding-pages': "Adding pages",
-          'moving-pages': "Moving pages",
-          'editing-pages': "Editing pages",
-          'deleting-pages': "Deleting pages",
-          'page-type': "Choosing the type of page",
-          'question-formats': "Choosing which question format to use",
-          'autocomplete': "Presenting users with a long list of options",
-          'file-upload': "Asking users to submit a file",
-          'optional': "Making a question optional",
-          'validation': "Validating user answers",
-          'markdown': "Formatting content with markdown",
-          'visibility': "Targeting content with visibility",
-          'welsh-translation': "Translating a form into Welsh",
-        }} %>
-      <section class="content-section content-section--with-top-border">
-        <h2 id="form-name" class="govuk-heading-m">Naming your form</h2>
-        <p>When you create a new form, you need to give it a name.</p>
-        <p>This name is:</p>
-        <ul>
-        <li>what your form will be listed as in the MoJ Forms editor</li>
-        <li>the title that will appear in your form's header</li>
-        <li>used to create your form's default URL</li>
-        </ul>
-        <p>A name can be up to 255 characters, including spaces.</p>
-        <p>Your form's name is important. It affects how people find your form (through search, for example) and helps them understand what it's for and if it's right for them.<p>
-        <p>A good name should:</p>
-        <ul>
-        <li>describe a task, not a team or department</li>
-        <li>use the same words your users would choose</li>
-        <li>start with an action, such as "Get help with..." or "Apply for..."</li> 
-        <li>be in sentence case (only capitalise the first word and proper nouns)</li>
-        </ul>
-        <p>Examples of government service names include:</p>
-        <ul>
-        <li>Register to vote</li>
-        <li>Get help with court fees</li>
-        <li>Renew your passport</li>
-        </ul>
-        <p>Don't worry if you are not sure what to call it at this stage. You will be able to <a class="govuk-link" href="/settings/#change-name">change your name and URL</a> in settings later.</p>
-        <p><a class="govuk-link" href="#top">Back to top</a></p>
-      </section>
-      <section class="content-section content-section--with-top-border">
-      <h2 id="flow-view" class="govuk-heading-m">Your initial view and pages</h2>
-        <p>When you create a new form, you are taken to your form's 'pages flow' or flow view. This shows how all the pages link together and is where you will build and edit your form. Most actions, such as adding and deleting pages, editing pages and creating branching, are done from the flow view.</p>
-        <p>You are given some default pages to help you structure your form:</p>
-        <ul>
-        <li>start page</li>
-        <li>check answers page</li>
-        <li>confirmation page</li>
-        </ul>
-        <p>The <a class="govuk-link" href="#footer">form footer</a> section also contains some pages which are required for your form and linked from your form's footer section.</p>
-        <img src="/images/start-pages.png" alt="A new form is created with a start page, check answers page and confirmation page." class="screenshot-image">
-        <p>The start page is your form's home page. It cannot be deleted but you can replace it with a <a class="govuk-link" href="#start-page">GOV.UK start page</a>.</p>
-        <p>All your form's question pages should come after the start page and before the check answers page.</p>
-        <h3 id="check-confirm" class="govuk-heading-s">Check answers and confirmation pages</h3>
-        <p>For your form to successfully submit the user data it collects, it must have a check answers page and a confirmation page. A form can have only one check answers page and one confirmation page. If you need to show different versions of these pages to your users, you may be able to achieve this effect with the <a class="govuk-link" href="#visibility">visibility setting</a>.</p>
-        <p><a class="govuk-link" href="#top">Back to top</a></p>
-      </section>
-      <section class="content-section content-section--with-top-border">
-      <h2 id="start-page" class="govuk-heading-m">Choosing the right start page</h2>
-      <p>Your form must have a start page. This is the starting point for your users. It should explain what the form is for, what information is required and whether there are any other ways to access the service you provide.</p>
-      <p>You can choose between 2 types of start page:</p>
-      <ul>
-      <li>an MoJ Forms start page - which you create as part of your form</li>
-      <li>a GOV.UK start page - which a GOV.UK publisher would create for you on GOV.UK</li>
-      </ul>
-      <h3 class="govuk-heading-s">When to use an MoJ Forms start page</h3>
-      <p>This is the default start page for every new form. You should use this start page unless you want your users to access your form from GOV.UK and all the information users need before starting your form will be on GOV.UK.</p>
-      <p>The MoJ Forms start page has some hints on what information to include. To find out more about what should go on your start page, read the <a class="govuk-link" href="https://design-system.service.gov.uk/patterns/start-using-a-service/">Design System guidance on start pages.</a></p>
-      <h3 class="govuk-heading-s">When to use a GOV.UK start page</h3>
-      <p>If your form is for an external audience, such as members of the public or a group of professionals, it may need a GOV.UK start page.</p>
-      <p>GOV.UK services must start on a GOV.UK content page. This links your service to the rest of GOV.UK, and means that users can find it using search or through GOV.UK’s navigation.</p>
-      <p>A GOV.UK start page may use a number of different templates depending on where on GOV.UK it will sit and what content is required.</p>
-      <p>You should talk to your local GOV.UK publishing team to decide:</p>
-      <ul>
-      <li>whether you need to link to your form from GOV.UK</li>
-      <li>where on GOV.UK it should link from</li>
-      <li>what to include on your start page</li>
-      <li>what other guidance or information your users may need</li>
-      <li>whether to use a GOV.UK start page or an MoJ Forms start page</li>
-      </ul>
-      <p>If your form is aimed at members of the public and will sit under services and information (sometimes called 'mainstream' content), your local GOV.UK publishing team will need to raise a request with the Government Digital Service (GDS) to make the changes.</p>
-    </section>
-    <h3 class="govuk-heading-s">How to switch to a GOV.UK start page</h3>
-    <p>From the flow view, hover over the start page thumbnail to reveal the page menu (...) and select 'Switch to GOV.UK start page'.</p>
-    <p>You will then be asked for a GOV.UK start page URL which you will get from your local GOV.UK publishing team.</p>
-    <p>When you switch to a GOV.UK start page, several things happen:</p>
-    <ul>
-    <li>your existing MoJ Forms start page is removed - but it's saved in the background and can be retrieved at any time by switching back</li>
-    <li>links to the start page, such as in your form's header, are updated to point to the GOV.UK URL</li>
-    </ul>
-    <p>You can test the URL is working in MoJ Forms by selecting 'Open start page' in the page menu. Bear in mind the link may not work or look correct until the GOV.UK publishing team push their work live.</p>
-    <p>The menu also includes an option to 'Edit start page URL'.</p>
-    <h3 class="govuk-heading-s">How to switch back to an MoJ Forms start page</h3>
-    <p>From the flow view, hover over the start page thumbnail to reveal the page menu (...) and select 'Switch to form start page'.</p>
-    <p><a class="govuk-link" href="#top">Back to top</a></p>
+
+<h1 class="govuk-heading-l"><%= current_page.data.heading %></h1>
+<p class="govuk-body-l">Learn how to start building your first form.</p>
+<h2 class="govuk-heading-m">Contents</h2> 
+<%= partial "toc", locals: { links: { 
+  'form-name': "Naming your form",
+  'flow-view': "Your initial view and pages",
+  'start-page': "Choosing the right start page",
+  'footer': "Footer pages",
+  'preview': "Previewing your pages",
+  'adding-pages': "Adding pages",
+  'moving-pages': "Moving pages",
+  'editing-pages': "Editing pages",
+  'deleting-pages': "Deleting pages",
+  'page-type': "Choosing the type of page",
+  'question-formats': "Choosing which question format to use",
+  'autocomplete': "Presenting users with a long list of options",
+  'file-upload': "Asking users to submit a file",
+  'optional': "Making a question optional",
+  'validation': "Validating user answers",
+  'markdown': "Formatting content with markdown",
+  'visibility': "Targeting content with visibility",
+  'welsh-translation': "Translating a form into Welsh",
+}} %>
+<section class="content-section content-section--with-top-border">
+  <h2 id="form-name" class="govuk-heading-m">Naming your form</h2>
+  <p>When you create a new form, you need to give it a name.</p>
+  <p>This name is:</p>
+  <ul>
+    <li>what your form will be listed as in the MoJ Forms editor</li>
+    <li>the title that will appear in your form's header</li>
+    <li>used to create your form's default URL</li>
+  </ul>
+  <p>A name can be up to 255 characters, including spaces.</p>
+  <p>Your form's name is important. It affects how people find your form (through search, for example) and helps them understand what it's for and if it's right for them.<p>
+  <p>A good name should:</p>
+  <ul>
+    <li>describe a task, not a team or department</li>
+    <li>use the same words your users would choose</li>
+    <li>start with an action, such as "Get help with..." or "Apply for..."</li> 
+    <li>be in sentence case (only capitalise the first word and proper nouns)</li>
+  </ul>
+  <p>Examples of government service names include:</p>
+  <ul>
+    <li>Register to vote</li>
+    <li>Get help with court fees</li>
+    <li>Renew your passport</li>
+  </ul>
+  <p>Don't worry if you are not sure what to call it at this stage. You will be able to <a class="govuk-link" href="/settings/#change-name">change your name and URL</a> in settings later.</p>
+  <p><a class="govuk-link" href="#top">Back to top</a></p>
+</section>
+<section class="content-section content-section--with-top-border">
+  <h2 id="flow-view" class="govuk-heading-m">Your initial view and pages</h2>
+  <p>When you create a new form, you are taken to your form's 'pages flow' or flow view. This shows how all the pages link together and is where you will build and edit your form. Most actions, such as adding and deleting pages, editing pages and creating branching, are done from the flow view.</p>
+  <p>You are given some default pages to help you structure your form:</p>
+  <ul>
+    <li>start page</li>
+    <li>check answers page</li>
+    <li>confirmation page</li>
+  </ul>
+  <p>The <a class="govuk-link" href="#footer">form footer</a> section also contains some pages which are required for your form and linked from your form's footer section.</p>
+  <img src="/images/start-pages.png" alt="A new form is created with a start page, check answers page and confirmation page." class="screenshot-image">
+  <p>The start page is your form's home page. It cannot be deleted but you can replace it with a <a class="govuk-link" href="#start-page">GOV.UK start page</a>.</p>
+  <p>All your form's question pages should come after the start page and before the check answers page.</p>
+  <h3 id="check-confirm" class="govuk-heading-s">Check answers and confirmation pages</h3>
+  <p>For your form to successfully submit the user data it collects, it must have a check answers page and a confirmation page. A form can have only one check answers page and one confirmation page. If you need to show different versions of these pages to your users, you may be able to achieve this effect with the <a class="govuk-link" href="#visibility">visibility setting</a>.</p>
+  <p><a class="govuk-link" href="#top">Back to top</a></p>
+</section>
+<section class="content-section content-section--with-top-border">
+  <h2 id="start-page" class="govuk-heading-m">Choosing the right start page</h2>
+  <p>Your form must have a start page. This is the starting point for your users. It should explain what the form is for, what information is required and whether there are any other ways to access the service you provide.</p>
+  <p>You can choose between 2 types of start page:</p>
+  <ul>
+    <li>an MoJ Forms start page - which you create as part of your form</li>
+    <li>a GOV.UK start page - which a GOV.UK publisher would create for you on GOV.UK</li>
+  </ul>
+  <h3 class="govuk-heading-s">When to use an MoJ Forms start page</h3>
+  <p>This is the default start page for every new form. You should use this start page unless you want your users to access your form from GOV.UK and all the information users need before starting your form will be on GOV.UK.</p>
+  <p>The MoJ Forms start page has some hints on what information to include. To find out more about what should go on your start page, read the <a class="govuk-link" href="https://design-system.service.gov.uk/patterns/start-using-a-service/">Design System guidance on start pages.</a></p>
+  <h3 class="govuk-heading-s">When to use a GOV.UK start page</h3>
+  <p>If your form is for an external audience, such as members of the public or a group of professionals, it may need a GOV.UK start page.</p>
+  <p>GOV.UK services must start on a GOV.UK content page. This links your service to the rest of GOV.UK, and means that users can find it using search or through GOV.UK’s navigation.</p>
+  <p>A GOV.UK start page may use a number of different templates depending on where on GOV.UK it will sit and what content is required.</p>
+  <p>You should talk to your local GOV.UK publishing team to decide:</p>
+  <ul>
+    <li>whether you need to link to your form from GOV.UK</li>
+    <li>where on GOV.UK it should link from</li>
+    <li>what to include on your start page</li>
+    <li>what other guidance or information your users may need</li>
+    <li>whether to use a GOV.UK start page or an MoJ Forms start page</li>
+  </ul>
+  <p>If your form is aimed at members of the public and will sit under services and information (sometimes called 'mainstream' content), your local GOV.UK publishing team will need to raise a request with the Government Digital Service (GDS) to make the changes.</p>
+  <h3 class="govuk-heading-s">How to switch to a GOV.UK start page</h3>
+  <p>From the flow view, hover over the start page thumbnail to reveal the page menu (...) and select 'Switch to GOV.UK start page'.</p>
+  <p>You will then be asked for a GOV.UK start page URL which you will get from your local GOV.UK publishing team.</p>
+  <p>When you switch to a GOV.UK start page, several things happen:</p>
+  <ul>
+  <li>your existing MoJ Forms start page is removed - but it's saved in the background and can be retrieved at any time by switching back</li>
+  <li>links to the start page, such as in your form's header, are updated to point to the GOV.UK URL</li>
+  </ul>
+  <p>You can test the URL is working in MoJ Forms by selecting 'Open start page' in the page menu. Bear in mind the link may not work or look correct until the GOV.UK publishing team push their work live.</p>
+  <p>The menu also includes an option to 'Edit start page URL'.</p>
+  <h3 class="govuk-heading-s">How to switch back to an MoJ Forms start page</h3>
+  <p>From the flow view, hover over the start page thumbnail to reveal the page menu (...) and select 'Switch to form start page'.</p>
+  <p><a class="govuk-link" href="#top">Back to top</a></p>
+</section>
     <section class="content-section content-section--with-top-border">
       <h2 id="footer" class="govuk-heading-m">Footer pages</h2>
       <p>Your form contains 3 pages that are linked from the footer section of every page of your form. These can be seen in the flow view under the heading of "form footer". They are:</p>
@@ -181,440 +175,436 @@ order: 3
       </section>
       <section class="content-section content-section--with-top-border">
       <h2 id="editing-pages" class="govuk-heading-m">Editing pages</h2>
-      <p>You can open a page to edit in 2 ways:
-      <ul>
-      <li>clicking directly on the page thumbnail</li>
-      <li>hovering over the page thumbnail to reveal the page menu (3 dots in a circle) and selecting 'edit page'</li>
-      </ul>
-      <p>Most text on a page can be edited. Just click on the text you want to change and start typing.</p>
-      <p>Some fields are required, like the page title, and others are optional. If a text area says it is optional, you don't have to delete it. The default text that appears in square brackets will be hidden in preview mode and when published.</p>
-      <p>Most text areas are set to a specific format, such as headings and hints. Text in content areas can be <a class="govuk-link" href="#markdown">formatted using markdown</a>.</p>
-      <p>Some text areas cannot be edited at the moment, including the buttons.</p>
-      <p><a class="govuk-link" href="#top">Back to top</a></p>
-    </section>
-      <section class="content-section content-section--with-top-border">
-        <h2 id="deleting-pages" class="govuk-heading-m">Deleting pages</h2>
-        <p>You can delete a page from the form flow view by hovering over the page thumbnail to reveal the page menu (3 dots in a circle) and selecting 'delete page'. This cannot be undone.</p>
-        <p>If you want to remove a page from your form without deleting it, you can move it to the unconnected pages section using the <a class="govuk-link" href="/branching/#change-next-page">'change next page'</a> option.</p>
-        <p><a class="govuk-link" href="#top">Back to top</a></p>
-      </section>
-      <section class="content-section content-section--with-top-border">
-        <h2 id="page-type" class="govuk-heading-m">Choosing the type of page</h2>
-        <p>When adding pages, you can choose from the following templates:</p>
-        <h3 id="page-templates" class="govuk-heading-s">Table: MoJ Forms page templates</h3>
-        <table style="font-family: Arial, Helvetica, sans-serif; text-align: left; border:1px solid #dee0e2;" border="1">
-        <thead>
-          <tr>
-            <th>Type of page</th>
-            <th>What it's for</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>Single question page</td>
-            <td>Allows only one question per page. All <a class="govuk-link" href="#question-formats">question types</a> are available.</td>
-          </tr>
-          <tr>
-            <td>Multiple question page</td>
-            <td>Allows any number of questions on a page. Most <a class="govuk-link" href="#question-formats">question types</a> are available.</td>
-          </tr>
-          <tr>
-            <td>Content page</td>
-            <td>Use to provide users with information without asking any questions, such as advice about the application process or the task they are trying to accomplish. Allows text and <a class="govuk-link" href="#markdown">markdown formatting</a> but no questions.</td>
-          </tr>
-          <tr>
-            <td>Exit page</td>
-            <td>Use to tell users they do not need to continue with the form, for example if they are ineligible for your service. Allows text and <a class="govuk-link" href="#markdown">markdown formatting</a> but no questions. There is no continue button. Inserting an exit page will break the flow to any following pages and move them to the unconnected pages section.</td>
-          </tr>
-          <tr>
-            <td>Check answers page</td>
-            <td>A page that allows users to check their answers before they submit them. You will only see this option if you deleted your <a class="govuk-link" href="#check-confirm">starting check answers page</a>. A form can have only one check answers page.</td>
-          </tr>
-          <tr>
-            <td>Confirmation page</td>
-            <td>The final page of a form which lets the user know they have finished. You will only see this option if you deleted your <a class="govuk-link" href="#check-confirm">starting confirmation page</a>. A form can have only one confirmation page.</td>
-          </tr>
-        </tbody>
-        </table>
-        <p></p>
-        <h3 id="page-single-multiple" class="govuk-heading-s">Single question or multiple question page?</h3>
-        <p>GOV.UK forms and services are built around the principle of <a class="govuk-link" href="https://www.gov.uk/service-manual/design/form-structure#start-with-one-thing-per-page">one thing per page</a>. In general, this is the easiest approach for users and it helps you get the highest quality responses. When you plan out your form, start with one question per page using single question page templates and only combine them on multiple question pages when it makes sense to do so. For example, you might decide to ask for a user's contact details on one page which could include an email address and telephone number.</p>
-        <p>It's not currently possible to convert a single question page into a different question type - such as from radio buttons to check boxes. It's also not possible to switch an existing page between a single question or multiple question format.</p>
-        <p>Questions can be reordered on multiple question pages using the up and down buttons. These appear when you click into the question title.</p>
-        <img src="/images/reorder-questions-example.gif" alt="This short animation shows several questions being reordered on a multi-question page. The page title is Your contact details and there are three text questions beneath it labelled telephone number, email address and full name. The cursor moves to email address and clicks in the question. 2 buttons appear to the right of the question with arrows pointing up and down. The cursor moves to the up button and clicks. The question moves up one position. This action is repeated twice with the full name question until the questions are in the order: full name, email address and telephone number." class="screenshot-image">
-        <p>The autocomplete and file upload question types are only available as single question pages.</p>
-        <p><a class="govuk-link" href="#top">Back to top</a></p>
-      </section>
-      <section class="content-section content-section--with-top-border">
-        <h2 id="question-formats" class="govuk-heading-m">Choosing which question format to use</h2>
-        <p>MoJ Forms has a wide range of question types. Picking the right format for your question will help ensure you get the highest quality responses from your users.</p>
-        <h3 id="text-question" class="govuk-heading-s">Text</h3>
-        <img src="/images/text-question.png" alt="An example of a text question. The question asks what is your full name." class="screenshot-image">
-        <p>Use the text question type when you want the user to enter a small amount of text such as a name or phone number. If the user might want to enter more than one line of text, use the <a class="govuk-link" href="#textarea-question">textarea question</a> type instead.</p>
-        <p>This question type allows you to set a <a class="govuk-link" href="#validation">minimum and maximum number of characters or words</a> for answers.</p>
-        <h3 id="textarea-question" class="govuk-heading-s">Textarea</h3>
-        <img src="/images/textarea-question.png" alt="An example of a textarea question. The title is tell us a little about your complaint. The hint text reads do not include any personal or financial information like your bank account or credit card number." class="screenshot-image">
-        <p>Use the textarea question type when the user might want to enter more than one line of text. Be clear and specific with your question and hint text so the user knows what is expected of them.</p>
-        <p>Don't use a textarea if there is a more structured way to collect the desired information using several questions.</p>
-        <p>This question type allows you to set a <a class="govuk-link" href="#validation">minimum and maximum number of characters or words</a> for answers. With a maximum answer length, it shows a counter as the user approaches and passes the limit.</p>
-        <h3 id="email-question" class="govuk-heading-s">Email address</h3>
-        <img src="/images/email-address-question.png" alt="An example of an email address question. The question asks what is youe full address? The hint text reads we will send a confirmation of your application to this address." class="screenshot-image">
-        <p>Use the email address question type to ask users for an email address. You must be clear why you are asking for it and how it will be used. (This should also be reflected in your <a class="govuk-link" href="/data-protection/#privacynotice">privacy notice</a>.) You must use this question type if you plan on sending users a <a class="govuk-link" href="/settings/#confirmation-email">confirmation email</a>.</p>
-        <p>This question type automatically checks that the answer looks like an email address (e.g. it contains an @ symbol).</p>
-        <h3 id="number-question" class="govuk-heading-s">Number</h3>
-        <img src="/images/number-question.png" alt="An example of a number question. The question asks what is your reference number? The hint text reads this is 8 digits long and will be on any correspondance you have received from us." class="screenshot-image">
-        <p>Use the number question type to ask users for a number.</p>
-        <p>This question type automatically checks that the answer contains only numbers and decimal points. Letters, spaces and other characters are not permitted. For this reason, don't use this question type to ask for telephone numbers as users might use brackets, spaces and so on. Use a text question for telephone numbers instead.</p>
-        <p>This question type allows you to set a <a class="govuk-link" href="#validation">minimum and maximum value</a> for answers. For example, only numbers up to 100 or numbers above 500.</p>
-        <h3 id="date-question" class="govuk-heading-s">Date</h3>
-        <img src="/images/date-question.png" alt="An example of a date question. The question asks when did you first contact us? The hint text reads for example, 23 1 2022." class="screenshot-image">
-        <p>Use the date question type to ask users for a date that they are likely to know, such as their date of birth. If the user is unlikely to know the exact date there are better options, such as <a class="govuk-link" href="#radio-question">radio buttons</a> offering users a choice or a <a class="govuk-link" href="#text-question">text</a> question allowing them to write in an answer.</p>
-        <p>This question type automatically checks that the days and months are valid possibilities. For example, a day can be up to 31 when the month is 1 but only 30 when the month is 9.</p>
-        <p>This question type allows you to set an <a class="govuk-link" href="#validation">earliest date and a latest date</a> for answers. For example, only dates before 1 January 2000 or dates after 31 December 2001.</p>
-        <h3 id="address-question" class="govuk-heading-s">Address</h3>
-        <img src="/images/address-question.png" alt="An example of an address question. The title reads: Your home address. There are text inputs with the labels: address line 1, address line 2 (optional), town or city, county (optional), postcode and country." class="screenshot-image">
-        <p>Use the address question type to ask users for a postal address.</p>
-        <p>This question type adds several text inputs in one block. The user can autofill it with any address information saved in their browser. The labels cannot be edited.</p>
-        <p>It is designed primarily for UK addresses and the country is prefilled with "United Kingdom". If the user keeps "United Kingdom" or replaces it with a UK country, such as England or Wales, the form will check if the postcode is in the proper format. It will not validate that the postcode is genuine or matches the address given.</p>
-        <p>Users may be able to use this question to enter an international address, for example by putting a zipcode in the postcode field. However, some users may struggle with this approach. You should test it with real users and decide whether it meets their needs or whether an alternative approach would work better. For example:</p>
-        <ul>
-        <li>if you know the address format of your users, you could use several text questions on a multi-question page with labels to match the format</li>
-        <li>if you don't know the address format of your users, or it's likely to vary, you could use a text area question and allow the user to enter their address in their own way</li>
-        </ul>
-        <p>If you create your own way to ask for an address, the user won't be able to autofill it with saved information from their browser.</p>
-        <h3 id="radio-question" class="govuk-heading-s">Radio buttons</h3>
-        <img src="/images/radio-question.png" alt="An example of a radio button question. The question asks is this the first time you have contacted us? There are 2 radio button options - yes and no." class="screenshot-image">
-        <p>Use the radio buttons question type to ask a user to select a single answer from a list. If the user can select multiple options, use <a class="govuk-link" href="#checkbox-question">checkboxes</a> instead.</p>
-        <p>If there are a lot of options, think about how they are ordered so a user can skim them easily and find the option that best fits.</p>
-        <p>If you want to offer an 'other' option, place this last. If you want the user to describe this other option, you can either:</p>
-        <ul>
-        <li>have an optional text or text area question beneath the radio buttons (using a multiple question page)</li>
-        <li>use branching to take those users to another page where you can ask more about the other option</li>
-        </ul>
-        <h3 id="checkbox-question" class="govuk-heading-s">Checkboxes</h3>
-        <img src="/images/checkbox-question.png" alt="An example of a checkbox question. The question asks what are your reasons for getting in touch? The hint text reads choose all that apply. There are 4 checkbox options - learn more, request a demo, discuss an opportunity and something else." class="screenshot-image">
-        <p>Use the checkboxes question type to allow users to select multiple answers from a list. If the user must select only a single option, use <a class="govuk-link" href="#radio-question">radio buttons</a> instead.</p>
-        <p>If there are a lot of options, think about how they are ordered so a user can skim them easily and find the option that best fits.</p>
-        <p>If you want to offer an 'other' option, place this last. If you want the user to describe this other option, you can either: </p>
-        <ul>
-        <li>have an optional text or text area question beneath the radio buttons (using a multiple question page)</li>
-        <li>use branching to take those users to another page where you can ask more about the other option</li>
-        </ul>
-        <h3 id="autocomplete-question" class="govuk-heading-s">Autocomplete</h3>
-        <img src="/images/autocomplete-question.png" alt="An example of an autocomplete question. The question asks which court did you attend?" class="screenshot-image">
-        <p>Use the autocomplete question type to help users select a single answer from a long list of options. The user can scroll through the list to select their answer or start typing to filter the options.</p>
-        <p>See the section on <a class="govuk-link" href="#autocomplete">presenting users with a long list of options</a> to learn more about how this question type works.</p>
-        <h3 id="file-question" class="govuk-heading-s">File upload</h3>
-        <img src="/images/file-upload-question.png" alt="An example of a file upload question. The title reads upload any evidence in support of your claim. The hint text reads maximum file size 7Mb." class="screenshot-image">
-        <p>Use the file upload question type to ask a user to attach a file to their form. A user can attach up to 10 files of up to 7MB each per page.</p>
-        See the section on <a class="govuk-link" href="#file-upload">asking users to submit a file</a> to learn more about how this question type works.</p>
-        <p><a class="govuk-link" href="#top">Back to top</a></p>
-      </section>
-      <section class="content-section content-section--with-top-border">
-      <h2 id="autocomplete" class="govuk-heading-m">Presenting users with a long list of options</h2>
-      <p>The autocomplete question type allows you to specify a large range of options for the user to choose from, such as a list of courts or locations. It looks like a text field with a black triangle, indicating a dropdown. When the user clicks into it the list of options appears. The user can scroll through the list to select their answer or start typing to filter the options. The form will only accept answers from the options specified.</p>
-      <img src="/images/autocomplete-example.gif" alt="This short animation shows an autocomplete question being filled in. The question is 'Which airport did you fly from?' and there is a blank text field beneath it. The cursor moves to the text field and a dropdown appears listing UK airports. The options are filtered as the letters 'l o n' are typed into the field and London Heathrow is selected." class="screenshot-image">
-      <p>This format is best when there are a lot of options to choose from. Smaller numbers of options are better presented using <a class="govuk-link" href="#radio-question">radio buttons</a>.</p>
-      <h3 id="autcomplete-formatting" class="govuk-heading-s">Formatting your autocomplete options</h3>
-      <p>Your autocomplete options must be uploaded to MoJ Forms in a comma-separated values (CSV) file. This is a plain text format that many applications use for exporting data.</p>
-      <p>The easiest way to create your autocomplete options is with a spreadsheet such as Microsoft Excel or Google Sheets. List your options in a column with a heading of 'Text', like this:</p>
-      <table>
-      <tr>
-          <th>Text</th>
-      </tr>
-      <tr>
-          <td>Glasgow</td>
-      </tr>
-      <tr>
-          <td>London Gatwick</td>
-      </tr>
-      <tr>
-          <td>London Heathrow</td>
-      </tr>
-      </table>
-      <p>You can also include a second column of information with a heading of 'Value'. For example, you might want to associate a code or number with each option. This won't be shown in the question but will be shown instead of the text in the PDF and CSV submitted at the end. (If you don't provide values, the PDF and CSV will contain the text.) For example:</p>
-      <table>
-    <tr>
-        <th>Text</th>
-        <th>Value</th>
-    </tr>
-    <tr>
-        <td>Glasgow</td>
-        <td>GLA</td>
-    </tr>
-    <tr>
-        <td>London Gatwick</td>
-        <td>LGW</td>
-    </tr>
-    <tr>
-        <td>London Heathrow</td>
-        <td>LHR</td>
-    </tr>
-    </table>
-    <p>When entering your options, ensure that:</p>
+    <p>You can open a page to edit in 2 ways:
     <ul>
+    <li>clicking directly on the page thumbnail</li>
+    <li>hovering over the page thumbnail to reveal the page menu (3 dots in a circle) and selecting 'edit page'</li>
+    </ul>
+    <p>Most text on a page can be edited. Just click on the text you want to change and start typing.</p>
+    <p>Some fields are required, like the page title, and others are optional. If a text area says it is optional, you don't have to delete it. The default text that appears in square brackets will be hidden in preview mode and when published.</p>
+    <p>Most text areas are set to a specific format, such as headings and hints. Text in content areas can be <a class="govuk-link" href="#markdown">formatted using markdown</a>.</p>
+    <p>Some text areas cannot be edited at the moment, including the buttons.</p>
+    <p><a class="govuk-link" href="#top">Back to top</a></p>
+  </section>
+<section class="content-section content-section--with-top-border">
+  <h2 id="deleting-pages" class="govuk-heading-m">Deleting pages</h2>
+  <p>You can delete a page from the form flow view by hovering over the page thumbnail to reveal the page menu (3 dots in a circle) and selecting 'delete page'. This cannot be undone.</p>
+  <p>If you want to remove a page from your form without deleting it, you can move it to the unconnected pages section using the <a class="govuk-link" href="/branching/#change-next-page">'change next page'</a> option.</p>
+  <p><a class="govuk-link" href="#top">Back to top</a></p>
+</section>
+<section class="content-section content-section--with-top-border">
+  <h2 id="page-type" class="govuk-heading-m">Choosing the type of page</h2>
+  <p>When adding pages, you can choose from the following templates:</p>
+  <h3 id="page-templates" class="govuk-heading-s">Table: MoJ Forms page templates</h3>
+  <table style="font-family: Arial, Helvetica, sans-serif; text-align: left; border:1px solid #dee0e2;" border="1">
+    <thead>
+      <tr>
+        <th>Type of page</th>
+        <th>What it's for</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Single question page</td>
+        <td>Allows only one question per page. All <a class="govuk-link" href="#question-formats">question types</a> are available.</td>
+      </tr>
+      <tr>
+        <td>Multiple question page</td>
+        <td>Allows any number of questions on a page. Most <a class="govuk-link" href="#question-formats">question types</a> are available.</td>
+      </tr>
+      <tr>
+        <td>Content page</td>
+        <td>Use to provide users with information without asking any questions, such as advice about the application process or the task they are trying to accomplish. Allows text and <a class="govuk-link" href="#markdown">markdown formatting</a> but no questions.</td>
+      </tr>
+      <tr>
+        <td>Exit page</td>
+        <td>Use to tell users they do not need to continue with the form, for example if they are ineligible for your service. Allows text and <a class="govuk-link" href="#markdown">markdown formatting</a> but no questions. There is no continue button. Inserting an exit page will break the flow to any following pages and move them to the unconnected pages section.</td>
+      </tr>
+      <tr>
+        <td>Check answers page</td>
+        <td>A page that allows users to check their answers before they submit them. You will only see this option if you deleted your <a class="govuk-link" href="#check-confirm">starting check answers page</a>. A form can have only one check answers page.</td>
+      </tr>
+      <tr>
+        <td>Confirmation page</td>
+        <td>The final page of a form which lets the user know they have finished. You will only see this option if you deleted your <a class="govuk-link" href="#check-confirm">starting confirmation page</a>. A form can have only one confirmation page.</td>
+      </tr>
+    </tbody>
+  </table>
+  <p></p>
+  <h3 id="page-single-multiple" class="govuk-heading-s">Single question or multiple question page?</h3>
+  <p>GOV.UK forms and services are built around the principle of <a class="govuk-link" href="https://www.gov.uk/service-manual/design/form-structure#start-with-one-thing-per-page">one thing per page</a>. In general, this is the easiest approach for users and it helps you get the highest quality responses. When you plan out your form, start with one question per page using single question page templates and only combine them on multiple question pages when it makes sense to do so. For example, you might decide to ask for a user's contact details on one page which could include an email address and telephone number.</p>
+  <p>It's not currently possible to convert a single question page into a different question type - such as from radio buttons to check boxes. It's also not possible to switch an existing page between a single question or multiple question format.</p>
+  <p>Questions can be reordered on multiple question pages using the up and down buttons. These appear when you click into the question title.</p>
+  <img src="/images/reorder-questions-example.gif" alt="This short animation shows several questions being reordered on a multi-question page. The page title is Your contact details and there are three text questions beneath it labelled telephone number, email address and full name. The cursor moves to email address and clicks in the question. 2 buttons appear to the right of the question with arrows pointing up and down. The cursor moves to the up button and clicks. The question moves up one position. This action is repeated twice with the full name question until the questions are in the order: full name, email address and telephone number." class="screenshot-image">
+  <p>The autocomplete and file upload question types are only available as single question pages.</p>
+  <p><a class="govuk-link" href="#top">Back to top</a></p>
+</section>
+  <section class="content-section content-section--with-top-border">
+  <h2 id="question-formats" class="govuk-heading-m">Choosing which question format to use</h2>
+  <p>MoJ Forms has a wide range of question types. Picking the right format for your question will help ensure you get the highest quality responses from your users.</p>
+  <h3 id="text-question" class="govuk-heading-s">Text</h3>
+  <img src="/images/text-question.png" alt="An example of a text question. The question asks what is your full name." class="screenshot-image">
+  <p>Use the text question type when you want the user to enter a small amount of text such as a name or phone number. If the user might want to enter more than one line of text, use the <a class="govuk-link" href="#textarea-question">textarea question</a> type instead.</p>
+  <p>This question type allows you to set a <a class="govuk-link" href="#validation">minimum and maximum number of characters or words</a> for answers.</p>
+  <h3 id="textarea-question" class="govuk-heading-s">Textarea</h3>
+  <img src="/images/textarea-question.png" alt="An example of a textarea question. The title is tell us a little about your complaint. The hint text reads do not include any personal or financial information like your bank account or credit card number." class="screenshot-image">
+  <p>Use the textarea question type when the user might want to enter more than one line of text. Be clear and specific with your question and hint text so the user knows what is expected of them.</p>
+  <p>Don't use a textarea if there is a more structured way to collect the desired information using several questions.</p>
+  <p>This question type allows you to set a <a class="govuk-link" href="#validation">minimum and maximum number of characters or words</a> for answers. With a maximum answer length, it shows a counter as the user approaches and passes the limit.</p>
+  <h3 id="email-question" class="govuk-heading-s">Email address</h3>
+  <img src="/images/email-address-question.png" alt="An example of an email address question. The question asks what is youe full address? The hint text reads we will send a confirmation of your application to this address." class="screenshot-image">
+  <p>Use the email address question type to ask users for an email address. You must be clear why you are asking for it and how it will be used. (This should also be reflected in your <a class="govuk-link" href="/data-protection/#privacynotice">privacy notice</a>.) You must use this question type if you plan on sending users a <a class="govuk-link" href="/settings/#confirmation-email">confirmation email</a>.</p>
+  <p>This question type automatically checks that the answer looks like an email address (e.g. it contains an @ symbol).</p>
+  <h3 id="number-question" class="govuk-heading-s">Number</h3>
+  <img src="/images/number-question.png" alt="An example of a number question. The question asks what is your reference number? The hint text reads this is 8 digits long and will be on any correspondance you have received from us." class="screenshot-image">
+  <p>Use the number question type to ask users for a number.</p>
+  <p>This question type automatically checks that the answer contains only numbers and decimal points. Letters, spaces and other characters are not permitted. For this reason, don't use this question type to ask for telephone numbers as users might use brackets, spaces and so on. Use a text question for telephone numbers instead.</p>
+  <p>This question type allows you to set a <a class="govuk-link" href="#validation">minimum and maximum value</a> for answers. For example, only numbers up to 100 or numbers above 500.</p>
+  <h3 id="date-question" class="govuk-heading-s">Date</h3>
+  <img src="/images/date-question.png" alt="An example of a date question. The question asks when did you first contact us? The hint text reads for example, 23 1 2022." class="screenshot-image">
+  <p>Use the date question type to ask users for a date that they are likely to know, such as their date of birth. If the user is unlikely to know the exact date there are better options, such as <a class="govuk-link" href="#radio-question">radio buttons</a> offering users a choice or a <a class="govuk-link" href="#text-question">text</a> question allowing them to write in an answer.</p>
+  <p>This question type automatically checks that the days and months are valid possibilities. For example, a day can be up to 31 when the month is 1 but only 30 when the month is 9.</p>
+  <p>This question type allows you to set an <a class="govuk-link" href="#validation">earliest date and a latest date</a> for answers. For example, only dates before 1 January 2000 or dates after 31 December 2001.</p>
+  <h3 id="address-question" class="govuk-heading-s">Address</h3>
+  <img src="/images/address-question.png" alt="An example of an address question. The title reads: Your home address. There are text inputs with the labels: address line 1, address line 2 (optional), town or city, county (optional), postcode and country." class="screenshot-image">
+  <p>Use the address question type to ask users for a postal address.</p>
+  <p>This question type adds several text inputs in one block. The user can autofill it with any address information saved in their browser. The labels cannot be edited.</p>
+  <p>It is designed primarily for UK addresses and the country is prefilled with "United Kingdom". If the user keeps "United Kingdom" or replaces it with a UK country, such as England or Wales, the form will check if the postcode is in the proper format. It will not validate that the postcode is genuine or matches the address given.</p>
+  <p>Users may be able to use this question to enter an international address, for example by putting a zipcode in the postcode field. However, some users may struggle with this approach. You should test it with real users and decide whether it meets their needs or whether an alternative approach would work better. For example:</p>
+  <ul>
+    <li>if you know the address format of your users, you could use several text questions on a multi-question page with labels to match the format</li>
+    <li>if you don't know the address format of your users, or it's likely to vary, you could use a text area question and allow the user to enter their address in their own way</li>
+  </ul>
+  <p>If you create your own way to ask for an address, the user won't be able to autofill it with saved information from their browser.</p>
+  <h3 id="radio-question" class="govuk-heading-s">Radio buttons</h3>
+  <img src="/images/radio-question.png" alt="An example of a radio button question. The question asks is this the first time you have contacted us? There are 2 radio button options - yes and no." class="screenshot-image">
+  <p>Use the radio buttons question type to ask a user to select a single answer from a list. If the user can select multiple options, use <a class="govuk-link" href="#checkbox-question">checkboxes</a> instead.</p>
+  <p>If there are a lot of options, think about how they are ordered so a user can skim them easily and find the option that best fits.</p>
+  <p>If you want to offer an 'other' option, place this last. If you want the user to describe this other option, you can either:</p>
+  <ul>
+    <li>have an optional text or text area question beneath the radio buttons (using a multiple question page)</li>
+    <li>use branching to take those users to another page where you can ask more about the other option</li>
+  </ul>
+  <h3 id="checkbox-question" class="govuk-heading-s">Checkboxes</h3>
+  <img src="/images/checkbox-question.png" alt="An example of a checkbox question. The question asks what are your reasons for getting in touch? The hint text reads choose all that apply. There are 4 checkbox options - learn more, request a demo, discuss an opportunity and something else." class="screenshot-image">
+  <p>Use the checkboxes question type to allow users to select multiple answers from a list. If the user must select only a single option, use <a class="govuk-link" href="#radio-question">radio buttons</a> instead.</p>
+  <p>If there are a lot of options, think about how they are ordered so a user can skim them easily and find the option that best fits.</p>
+  <p>If you want to offer an 'other' option, place this last. If you want the user to describe this other option, you can either: </p>
+  <ul>
+    <li>have an optional text or text area question beneath the radio buttons (using a multiple question page)</li>
+    <li>use branching to take those users to another page where you can ask more about the other option</li>
+  </ul>
+  <h3 id="autocomplete-question" class="govuk-heading-s">Autocomplete</h3>
+  <img src="/images/autocomplete-question.png" alt="An example of an autocomplete question. The question asks which court did you attend?" class="screenshot-image">
+  <p>Use the autocomplete question type to help users select a single answer from a long list of options. The user can scroll through the list to select their answer or start typing to filter the options.</p>
+  <p>See the section on <a class="govuk-link" href="#autocomplete">presenting users with a long list of options</a> to learn more about how this question type works.</p>
+  <h3 id="file-question" class="govuk-heading-s">File upload</h3>
+  <img src="/images/file-upload-question.png" alt="An example of a file upload question. The title reads upload any evidence in support of your claim. The hint text reads maximum file size 7Mb." class="screenshot-image">
+  <p>Use the file upload question type to ask a user to attach a file to their form. A user can attach up to 10 files of up to 7MB each per page.</p>
+  See the section on <a class="govuk-link" href="#file-upload">asking users to submit a file</a> to learn more about how this question type works.</p>
+  <p><a class="govuk-link" href="#top">Back to top</a></p>
+</section>
+<section class="content-section content-section--with-top-border">
+  <h2 id="autocomplete" class="govuk-heading-m">Presenting users with a long list of options</h2>
+  <p>The autocomplete question type allows you to specify a large range of options for the user to choose from, such as a list of courts or locations. It looks like a text field with a black triangle, indicating a dropdown. When the user clicks into it the list of options appears. The user can scroll through the list to select their answer or start typing to filter the options. The form will only accept answers from the options specified.</p>
+  <img src="/images/autocomplete-example.gif" alt="This short animation shows an autocomplete question being filled in. The question is 'Which airport did you fly from?' and there is a blank text field beneath it. The cursor moves to the text field and a dropdown appears listing UK airports. The options are filtered as the letters 'l o n' are typed into the field and London Heathrow is selected." class="screenshot-image">
+  <p>This format is best when there are a lot of options to choose from. Smaller numbers of options are better presented using <a class="govuk-link" href="#radio-question">radio buttons</a>.</p>
+  <h3 id="autcomplete-formatting" class="govuk-heading-s">Formatting your autocomplete options</h3>
+  <p>Your autocomplete options must be uploaded to MoJ Forms in a comma-separated values (CSV) file. This is a plain text format that many applications use for exporting data.</p>
+  <p>The easiest way to create your autocomplete options is with a spreadsheet such as Microsoft Excel or Google Sheets. List your options in a column with a heading of 'Text', like this:</p>
+  <table>
+    <tr>
+      <th>Text</th>
+    </tr>
+    <tr>
+      <td>Glasgow</td>
+    </tr>
+    <tr>
+      <td>London Gatwick</td>
+    </tr>
+    <tr>
+      <td>London Heathrow</td>
+    </tr>
+  </table>
+  <p>You can also include a second column of information with a heading of 'Value'. For example, you might want to associate a code or number with each option. This won't be shown in the question but will be shown instead of the text in the PDF and CSV submitted at the end. (If you don't provide values, the PDF and CSV will contain the text.) For example:</p>
+  <table>
+    <tr>
+      <th>Text</th>
+      <th>Value</th>
+    </tr>
+    <tr>
+      <td>Glasgow</td>
+      <td>GLA</td>
+    </tr>
+    <tr>
+      <td>London Gatwick</td>
+      <td>LGW</td>
+    </tr>
+    <tr>
+      <td>London Heathrow</td>
+      <td>LHR</td>
+    </tr>
+  </table>
+  <p>When entering your options, ensure that:</p>
+  <ul>
     <li>you have either one or 2 columns of information</li>
     <li>the headings are exactly as shown here</li>
     <li>the options are ordered alphabetically</li>
     <li>there are no blank cells</li>
-    </ul>
-    <p>Remember to save your options as CSV when you are ready to upload them to your form. (If your application gives you a choice of CSV types, use the standard “Comma-separated Values (.csv)” option.) There is a maximum file size of 1Mb.</p>
-    <h3 id="autocomplete-uploading" class="govuk-heading-s">Uploading your autocomplete options</h3>
-    <p>To upload your options, open your autocomplete page in edit mode. Click in the question title to show the component menu (...) and select 'Autocomplete options'.</p>
-    <img src="/images/autocomplete-editor.png" alt="Screenshot of an autocomplete question being edited in MoJ Forms. The component menu is open and the autocomplete options link is highlighted." class="screenshot-image">
-    <p>The page includes a blue warning message to indicate whether any options have been uploaded. After uploading, you won't be able to see your options on the page. You will need to save your changes and test them either in <a class="govuk-link" href="#preview">preview mode</a> or after <a class="govuk-link" href="/testing-and-publishing/#test">publishing to Test</a>.</p>
-    <p>It's not currently possible to edit your options once they have been uploaded. To change the options, you will need to upload a new file.</p>
-    <p><a class="govuk-link" href="#top">Back to top</a></p>
-    </section> 
-    <section class="content-section content-section--with-top-border">
-        <h2 id="file-upload" class="govuk-heading-m">Asking users to submit a file</h2>
-        <p>The file upload question type allows you to ask users to attach files to their form.</p>
-        <p>By default, the question allows the user to attach only 1 file per page but you can increase this number up to a maximum of 10. This can be useful if:</p>
-        <ul>
-        <li>you don't know how many files the user might want to upload</li>
-        <li>the user is likely to have several files of the same type, such as receipts or proofs of ID</li>
-        </ul>
-        <p>In many cases, it may still be better to ask for files over several different pages, rather than all in one go. This approach enables you to be more explicit with the user about what they need to provide and ensure they provide all the required files.</p>
-        <p>To set a maximum number of files, click in the question title to highlight the component settings button (...) and select "Number of files…"</p>
-        <p>MoJ Forms supports the following file formats up to 7MB in size:</p>
-        <ul>
-        <li>portable document format (.pdf)</li>
-        <li>comma-separated values (.csv)</li>
-        <li>images (.jpg, .jpeg, .png)</li>
-        <li>MS Excel (.xls, xlsx)</li>
-        <li>MS Word (.doc, .docx)</li>
-        <li>Open Office (.odt, .ods)</li>
-        <li>plain text (.txt)</li>
-        <li>rich text (.rtf)</li>
-        </ul>
-        <p>File names may be altered during the upload process to:</p>
-        <ul>
-        <li>remove any unsupported special characters such as ? and *</li>
-        <li>remove any part of a file name that comes before a \ - for example, report\version1.doc would be renamed to version1.doc</li>
-        <li>differentiate any identically named files with a number - for example, instead of several documents all named document.xls, you would receive document.xls, document-(1).xls, document-(2).xls and so on</li>
-        </ul>
-        <p><a class="govuk-link" href="#top">Back to top</a></p>
-      </section>
-      <section class="content-section content-section--with-top-border">
-        <h2 id="optional" class="govuk-heading-m">Making a question optional</h2>
-        <p>When a question is required, the form will check that the user has provided an answer before moving to the next page. If they haven't, it will show an error message and prompt the user to complete the question.</p>
-        <p>All questions are required by default but you can switch this setting off to make a question optional. This can be done with both single question pages and individual questions on multi-question pages.</p>
-        <p>To make a question optional, first click in the question title as if you are going to edit it. This highlights the component settings button (3 dots in a circle). Clicking on the button will open the menu.</p>
-        <img src="/images/required-or-optional.png" alt="The option to make a question optional is in the component settings menu." class="screenshot-image">
-        <p>Click on the 'Required' setting to open the options, where you can set it to either 'yes' (required) or 'no'.</p>
-        <p>MoJ Forms automatically adds '(optional)' onto the end of the title of any question that isn't required.</p>
-        <p><a class="govuk-link" href="#top">Back to top</a></p>
-      </section>
-      <section class="content-section content-section--with-top-border">
-      <h2 id="validation" class="govuk-heading-m">Validating user answers</h2>
-      <p>You can set validation criteria for a range of question types, allowing you to specify things like the length or limits of an answer. When validation is present, the form will check the user's answers before moving to the next page and show an appropriate error if required.</p>
-      <p>The full range of options available are shown in this table:</p>
-      <h3 id="validation-options" class="govuk-heading-s">Table: validation options</h3>
-      <table style="font-family: Arial, Helvetica, sans-serif; text-align: left; border:1px solid #dee0e2;" border="1">
-      <thead>
-        <tr>
-          <th>Validation</th>
-          <th>Available with</th>
-          <th>What it does</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>Minimum answer length</td>
-          <td>Text<br>Text area</td>
-          <td>Sets the minimum number of characters (or words with text area) that will be accepted</td>
-        </tr>
-        <tr>
-          <td>Maximum answer length</td>
-          <td>Text<br>Text area</td>
-          <td>Sets the maximum number of characters (or words with text area) that will be accepted</td>
-        </tr>
-        <tr>
-          <td>Minimum answer value</td>
-          <td>Number</td>
-          <td>Sets the lowest number that will be accepted</td>
-        </tr>
-        <tr>
-          <td>Maximum answer value</td>
-          <td>Number</td>
-          <td>Sets the highest number that will be accepted</td>
-        </tr>
-        <tr>
-          <td>Earliest date</td>
-          <td>Date</td>
-          <td>Sets the earliest date that will be accepted</td>
-        </tr>
-        <tr>
-          <td>Latest date</td>
-          <td>Date</td>
-          <td>Sets the latest data that will be accepted</td>
-        </tr>
-        <tr>
+  </ul>
+  <p>Remember to save your options as CSV when you are ready to upload them to your form. (If your application gives you a choice of CSV types, use the standard “Comma-separated Values (.csv)” option.) There is a maximum file size of 1Mb.</p>
+  <h3 id="autocomplete-uploading" class="govuk-heading-s">Uploading your autocomplete options</h3>
+  <p>To upload your options, open your autocomplete page in edit mode. Click in the question title to show the component menu (...) and select 'Autocomplete options'.</p>
+  <img src="/images/autocomplete-editor.png" alt="Screenshot of an autocomplete question being edited in MoJ Forms. The component menu is open and the autocomplete options link is highlighted." class="screenshot-image">
+  <p>The page includes a blue warning message to indicate whether any options have been uploaded. After uploading, you won't be able to see your options on the page. You will need to save your changes and test them either in <a class="govuk-link" href="#preview">preview mode</a> or after <a class="govuk-link" href="/testing-and-publishing/#test">publishing to Test</a>.</p>
+  <p>It's not currently possible to edit your options once they have been uploaded. To change the options, you will need to upload a new file.</p>
+  <p><a class="govuk-link" href="#top">Back to top</a></p>
+</section> 
+<section class="content-section content-section--with-top-border">
+  <h2 id="file-upload" class="govuk-heading-m">Asking users to submit a file</h2>
+  <p>The file upload question type allows you to ask users to attach files to their form.</p>
+  <p>By default, the question allows the user to attach only 1 file per page but you can increase this number up to a maximum of 10. This can be useful if:</p>
+  <ul>
+    <li>you don't know how many files the user might want to upload</li>
+    <li>the user is likely to have several files of the same type, such as receipts or proofs of ID</li>
+  </ul>
+  <p>In many cases, it may still be better to ask for files over several different pages, rather than all in one go. This approach enables you to be more explicit with the user about what they need to provide and ensure they provide all the required files.</p>
+  <p>To set a maximum number of files, click in the question title to highlight the component settings button (...) and select "Number of files…"</p>
+  <p>MoJ Forms supports the following file formats up to 7MB in size:</p>
+  <ul>
+    <li>portable document format (.pdf)</li>
+    <li>comma-separated values (.csv)</li>
+    <li>images (.jpg, .jpeg, .png)</li>
+    <li>MS Excel (.xls, xlsx)</li>
+    <li>MS Word (.doc, .docx)</li>
+    <li>Open Office (.odt, .ods)</li>
+    <li>plain text (.txt)</li>
+    <li>rich text (.rtf)</li>
+  </ul>
+  <p>File names may be altered during the upload process to:</p>
+  <ul>
+    <li>remove any unsupported special characters such as ? and *</li>
+    <li>remove any part of a file name that comes before a \ - for example, report\version1.doc would be renamed to version1.doc</li>
+    <li>differentiate any identically named files with a number - for example, instead of several documents all named document.xls, you would receive document.xls, document-(1).xls, document-(2).xls and so on</li>
+  </ul>
+  <p><a class="govuk-link" href="#top">Back to top</a></p>
+</section>
+<section class="content-section content-section--with-top-border">
+  <h2 id="optional" class="govuk-heading-m">Making a question optional</h2>
+  <p>When a question is required, the form will check that the user has provided an answer before moving to the next page. If they haven't, it will show an error message and prompt the user to complete the question.</p>
+  <p>All questions are required by default but you can switch this setting off to make a question optional. This can be done with both single question pages and individual questions on multi-question pages.</p>
+  <p>To make a question optional, first click in the question title as if you are going to edit it. This highlights the component settings button (3 dots in a circle). Clicking on the button will open the menu.</p>
+  <img src="/images/required-or-optional.png" alt="The option to make a question optional is in the component settings menu." class="screenshot-image">
+  <p>Click on the 'Required' setting to open the options, where you can set it to either 'yes' (required) or 'no'.</p>
+  <p>MoJ Forms automatically adds '(optional)' onto the end of the title of any question that isn't required.</p>
+  <p><a class="govuk-link" href="#top">Back to top</a></p>
+</section>
+<section class="content-section content-section--with-top-border">
+  <h2 id="validation" class="govuk-heading-m">Validating user answers</h2>
+  <p>You can set validation criteria for a range of question types, allowing you to specify things like the length or limits of an answer. When validation is present, the form will check the user's answers before moving to the next page and show an appropriate error if required.</p>
+  <p>The full range of options available are shown in this table:</p>
+  <h3 id="validation-options" class="govuk-heading-s">Table: validation options</h3>
+  <table style="font-family: Arial, Helvetica, sans-serif; text-align: left; border:1px solid #dee0e2;" border="1">
+    <thead>
+      <tr>
+        <th>Validation</th>
+        <th>Available with</th>
+        <th>What it does</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Minimum answer length</td>
+        <td>Text<br>Text area</td>
+        <td>Sets the minimum number of characters (or words with text area) that will be accepted</td>
+      </tr>
+      <tr>
+        <td>Maximum answer length</td>
+        <td>Text<br>Text area</td>
+        <td>Sets the maximum number of characters (or words with text area) that will be accepted</td>
+      </tr>
+      <tr>
+        <td>Minimum answer value</td>
+        <td>Number</td>
+        <td>Sets the lowest number that will be accepted</td>
+      </tr>
+      <tr>
+        <td>Maximum answer value</td>
+        <td>Number</td>
+        <td>Sets the highest number that will be accepted</td>
+      </tr>
+      <tr>
+        <td>Earliest date</td>
+        <td>Date</td>
+        <td>Sets the earliest date that will be accepted</td>
+      </tr>
+      <tr>
+        <td>Latest date</td>
+        <td>Date</td>
+        <td>Sets the latest data that will be accepted</td>
+      </tr>
+      <tr>
         <td>Specific answer format (regex)</td>
         <td>Text<br>Textarea</td>
         <td>Allows use of <a class="govuk-link" href="#regex">regular expressions (regex)</a> to specify a format such as a reference number or case ID</td>
       </tr>
-        <tr>
-          <td>Maximum number of files</td>
-          <td>File upload</td>
-          <td>Sets the maximum number of files that can be uploaded to that page</td>
-        </tr>
-      </tbody>
-      </table>
-      <p>To set validation, click in the question title to highlight the component settings button (3 dots in a circle) and click to open the menu. Validation options are listed in the menu.</p>
-      <img src="/images/validation-modal.png" alt="The settings for maximum answer length allow you to specify the highest number of characters or words that will be accepted." class="screenshot-image">
-      <h3 id="regex" class="govuk-heading-s">About regular expressions</h3>
-      <p>A regular expression (regex) is a way of defining a pattern of characters. When you apply this to a question, the form checks if an answer matches that pattern.</p>
-      <p>For example, you might want to ask your users for a case reference that can be 8 to 11 letters long. The regex for this would look like:</p>
-      <p>[a-z]{8,11}</p>
-      <p>Regex 'options', which allow some additional flexibility, are not currently supported.</p>
-      <p>Regex uses programming language and can get quite complex, depending on what you want it to do. For this reason, we recommend that you get help from an expert, such as a developer, to write it for you.</p>
-      <p>There is always a risk when using a regex that you might inadvertently prevent some users from being able to complete your form. This can happen if you make a mistake in the regex or if you apply a pattern that doesn't work for all of your users.</p>
-      <p>MoJ Forms does not check to see if your regex is working correctly when applying it. You can check if your regex matches a particular answer using an online editor such as <a class="govuk-link" href="https://rubular.com/">Rublar</a>. You should also conduct proper testing with users.</p>
-      <p><a class="govuk-link" href="#top">Back to top</a></p>
-    </section>
-      <section class="content-section content-section--with-top-border">
-        <h2 id="markdown" class="govuk-heading-m">Formatting content with markdown</h2>
-        <p>In most cases, you won't have to worry about formatting. The page templates include fields for headings, labels and hint text and all you have to do is add your own words.</p>
-        <p>Content areas allow you to use markdown to add your own formatting. These are on every content page and can be added to some other page templates as required.</p>
-        <p>Markdown is a way of adding formatting to plain text using basic symbols and patterns. With markdown, you can add headings, links, lists, tables and more. For example, to create a bulleted list, you start each item with an asterisk (*). MoJ Forms supports the following markdown styles.</p>
-        <h3 id="markdown-formatting" class="govuk-heading-s">Table: markdown formatting</h3>
-        <table style="font-family: Arial, Helvetica, sans-serif; text-align: left; border:1px solid #dee0e2;" border="1">
-<thead>
-  <tr>
-    <th>Formatting</th>
-    <th>Markdown </th>
-    <th>Example</th>
-  </tr>
-</thead>
-<tbody>
-  <tr>
-    <td>Headings</td>
-    <td>Put 2, 3 or 4 hashtags at the beginning of your header, depending on the level of heading you need.</td>
-    <td>## Level 2 heading<br>### Level 3 heading<br>#### Level 4 heading</td>
-  </tr>
-  <tr>
-    <td>Bold</td>
-    <td>Put the words you want to make bold inside double asterisks.</td>
-    <td>make **these words** bold</td>
-  </tr>
-  <tr>
-    <td>Italic</td>
-    <td>Put the words you want in italics inside single asterisks.</td>
-    <td>make *these words* italic</td>
-  </tr>
-  <tr>
-    <td>Bullets</td>
-    <td>Put an asterisk (or a hyphen) at the start of each item in your list and leave blank lines at the beginning and end of the list.</td>
-    <td>Bulleted lists look like this: <br>* list item 1<br>* list item 2<br>* list item 3</td>
-  </tr>
-  <tr>
-    <td>Numbering</td>
-    <td>Put a number with a full stop and space at the start of each item and leave blank lines at the beginning and end of the list.</td>
-    <td>Numbered lists look like this:<br>1. list item 1<br>2. list item 2<br>3. list item 3 </td>
-  </tr>
-  <tr>
-    <td>Web links</td>
-    <td>Put the link text in square brackets followed immediately by the link url in round brackets.</td>
-    <td>[link to GOV.UK](https://www.gov.uk/)</td>
-  </tr>
-  <tr>
-    <td>Email links</td>
-    <td>Put 'less than' and 'greater than' signs around the email address.</td>
-    <td>&lt;email@address.com&gt;</td>
-  </tr>
-  <tr>
-    <td>Tables</td>
-    <td>Use dividers (or 'pipes') to split your content into columns and start each row on a new line. Make sure each row has the same number of columns. Put hyphens in the second row to make the first row a header row. Leave blank lines at the beginning and end of the table.</td>
-    <td>2 columns: <br>| Header 1 | Header 2 |<br>| -------- | -------- |<br>| Cell | Cell |<br>| Cell | Cell |<br>3 columns: <br>| Header 1 | Header 2 | Header 3 |<br>| -------- | -------- | -------- |<br>| Cell | Cell | Cell |<br>| Cell | Cell | Cell |</td>
-  </tr>
-  <tr>
-    <td>Call to action</td>
-    <td>Put $CTA on the lines before and after the text you want in the box.</td>
-    <td>$CTA<br>This markdown creates a tinted box. You can use it to highlight important links and information.<br>$CTA</td>
-  </tr>
-  <tr>
-    <td>Inset text (information callout)</td>
-    <td>Put ^ before and after the text you want to inset.</td>
-    <td>^This indents text and can be used to highlight useful information.^</td>
-  </tr>
-  <tr>
-    <td>Warning text (warning callout)</td>
-    <td>Put % before and after the text you want in the warning.</td>
-    <td>%This adds a warning icon and can be used to highlight something important.%</td>
-  </tr>
-  <tr>
-    <td>Contacts</td>
-    <td>Put $C on the lines before and after your contact details. Add 2 spaces at the end of each line within the contact details.</td>
-    <td>$C<br>
-    Email: contact.us@team.gov.uk  <br>
-    Telephone:01234 555666  <br>
-    Monday to Friday, 8am to 5pm  <br>
-    $C</td>
-  </tr>
-  <tr>
-    <td>Addresses</td>
-    <td>Put $A on the lines before and after your address. Add 2 spaces at the end of each line within the address.</td>
-    <td>$A<br>
-    Ministry of Justice  <br>
-    102 Petty France  <br>
-    London  <br>
-    SW1H 9AJ  <br>
-    $A</td>
-  </tr>
-</tbody>
-</table>
-<p><a class="govuk-link" href="#top">Back to top</a></p>
+      <tr>
+        <td>Maximum number of files</td>
+        <td>File upload</td>
+        <td>Sets the maximum number of files that can be uploaded to that page</td>
+      </tr>
+    </tbody>
+  </table>
+  <p>To set validation, click in the question title to highlight the component settings button (3 dots in a circle) and click to open the menu. Validation options are listed in the menu.</p>
+  <img src="/images/validation-modal.png" alt="The settings for maximum answer length allow you to specify the highest number of characters or words that will be accepted." class="screenshot-image">
+  <h3 id="regex" class="govuk-heading-s">About regular expressions</h3>
+  <p>A regular expression (regex) is a way of defining a pattern of characters. When you apply this to a question, the form checks if an answer matches that pattern.</p>
+  <p>For example, you might want to ask your users for a case reference that can be 8 to 11 letters long. The regex for this would look like:</p>
+  <p>[a-z]{8,11}</p>
+  <p>Regex 'options', which allow some additional flexibility, are not currently supported.</p>
+  <p>Regex uses programming language and can get quite complex, depending on what you want it to do. For this reason, we recommend that you get help from an expert, such as a developer, to write it for you.</p>
+  <p>There is always a risk when using a regex that you might inadvertently prevent some users from being able to complete your form. This can happen if you make a mistake in the regex or if you apply a pattern that doesn't work for all of your users.</p>
+  <p>MoJ Forms does not check to see if your regex is working correctly when applying it. You can check if your regex matches a particular answer using an online editor such as <a class="govuk-link" href="https://rubular.com/">Rublar</a>. You should also conduct proper testing with users.</p>
+  <p><a class="govuk-link" href="#top">Back to top</a></p>
 </section>
 <section class="content-section content-section--with-top-border">
-        <h2 id="visibility" class="govuk-heading-m">Targeting content with visibility</h2>
-        <p>Visibility is what we call being able to show users different blocks of content based on their previous answers. With visibility, you can change or hide some of the content on the page for different users.</p>
-        <p>It's also a really powerful tool for creating <a class="govuk=link" href="https://gds.blog.gov.uk/2012/02/16/smart-answers-are-smart/">'smart answer' services</a> where you ask the user a series of questions and provide information tailored to their answers. Visibility allows you to use a single information page to serve dozens of different combinations of answers.</p>
-        <p>Visibility is a setting on all content areas - the text boxes that allow you to add paragraphs of content and use markdown formatting. These are on content pages, exit pages, the confirmation page and a number of other <a class="govuk-link" href="#page-type">page templates</a>.</p>
-        <p>Visibility allows you to set a content area to show:</p>
-        <ul>
-        <li>always (the default setting)</li>
-        <li>never</li>
-        <li>only if…</li>
-        </ul>
-        <p>With "only if…" you set the conditions under which the content area will show. For example, only show if a user answered yes to a previous question or selected a specific option. It works just like <a class="govuk-link" href="/branching/">branching</a>, only you are creating rules on a page rather than between pages. And as with branching, visibility rules can only be based on radio button or checkbox questions at the moment.</p>
-        <h3 class="govuk-heading-s">Setting a content area's visibility</h3>
-        <p>To set the visibility of a content area, click in the content area to highlight the component settings button (...) and click to open the menu. Select "show if…" to open the settings window and choose between the 3 options (show always, only if… or never).</p>
-        <p>When you select "only if…", the window will expand to allow you to input your conditions.</p>
-        <p>A condition consists of:</p>
-        <ul>
-        <li>the question that the visibility will be based on</li>
-        <li>an operator - such as 'is' or 'is not'</li>
-        <li>the user's answer</li>
-        </ul>
-        <p>For example, a condition could be:</p>
-        <ul>
-        <li>question - what is your favourite colour?</li>
-        <li>operator - is</li>
-        <li>answer - red</li>
-        </ul>
-        <p>In this example, the content area would only show to users who said red was their favourite colour.</p>
-        <p>A content area can have as many conditions as you need.</p>
-        <p>A page will show all content areas in the MoJ Forms editor and when you preview the individual page, regardless of visibility settings. That's because you need the relevant answers to previous questions for the settings to apply. To check how a page will appear to users, you will need to start your form from the beginning, using either the <a class="govuk-link" href="#preview">“preview form” feature</a> or when published to Test.</p>
-        <p><a class="govuk-link" href="#top">Back to top</a></p>
-      </section>
+  <h2 id="markdown" class="govuk-heading-m">Formatting content with markdown</h2>
+  <p>In most cases, you won't have to worry about formatting. The page templates include fields for headings, labels and hint text and all you have to do is add your own words.</p>
+  <p>Content areas allow you to use markdown to add your own formatting. These are on every content page and can be added to some other page templates as required.</p>
+  <p>Markdown is a way of adding formatting to plain text using basic symbols and patterns. With markdown, you can add headings, links, lists, tables and more. For example, to create a bulleted list, you start each item with an asterisk (*). MoJ Forms supports the following markdown styles.</p>
+  <h3 id="markdown-formatting" class="govuk-heading-s">Table: markdown formatting</h3>
+    <table style="font-family: Arial, Helvetica, sans-serif; text-align: left; border:1px solid #dee0e2;" border="1">
+    <thead>
+      <tr>
+        <th>Formatting</th>
+        <th>Markdown </th>
+        <th>Example</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Headings</td>
+        <td>Put 2, 3 or 4 hashtags at the beginning of your header, depending on the level of heading you need.</td>
+        <td>## Level 2 heading<br>### Level 3 heading<br>#### Level 4 heading</td>
+      </tr>
+      <tr>
+        <td>Bold</td>
+        <td>Put the words you want to make bold inside double asterisks.</td>
+        <td>make **these words** bold</td>
+      </tr>
+      <tr>
+        <td>Italic</td>
+        <td>Put the words you want in italics inside single asterisks.</td>
+        <td>make *these words* italic</td>
+      </tr>
+      <tr>
+        <td>Bullets</td>
+        <td>Put an asterisk (or a hyphen) at the start of each item in your list and leave blank lines at the beginning and end of the list.</td>
+        <td>Bulleted lists look like this: <br>* list item 1<br>* list item 2<br>* list item 3</td>
+      </tr>
+      <tr>
+        <td>Numbering</td>
+        <td>Put a number with a full stop and space at the start of each item and leave blank lines at the beginning and end of the list.</td>
+        <td>Numbered lists look like this:<br>1. list item 1<br>2. list item 2<br>3. list item 3 </td>
+      </tr>
+      <tr>
+        <td>Web links</td>
+        <td>Put the link text in square brackets followed immediately by the link url in round brackets.</td>
+        <td>[link to GOV.UK](https://www.gov.uk/)</td>
+      </tr>
+      <tr>
+        <td>Email links</td>
+        <td>Put 'less than' and 'greater than' signs around the email address.</td>
+        <td>&lt;email@address.com&gt;</td>
+      </tr>
+      <tr>
+        <td>Tables</td>
+        <td>Use dividers (or 'pipes') to split your content into columns and start each row on a new line. Make sure each row has the same number of columns. Put hyphens in the second row to make the first row a header row. Leave blank lines at the beginning and end of the table.</td>
+        <td>2 columns: <br>| Header 1 | Header 2 |<br>| -------- | -------- |<br>| Cell | Cell |<br>| Cell | Cell |<br>3 columns: <br>| Header 1 | Header 2 | Header 3 |<br>| -------- | -------- | -------- |<br>| Cell | Cell | Cell |<br>| Cell | Cell | Cell |</td>
+      </tr>
+      <tr>
+        <td>Call to action</td>
+        <td>Put $CTA on the lines before and after the text you want in the box.</td>
+        <td>$CTA<br>This markdown creates a tinted box. You can use it to highlight important links and information.<br>$CTA</td>
+      </tr>
+      <tr>
+        <td>Inset text (information callout)</td>
+        <td>Put ^ before and after the text you want to inset.</td>
+        <td>^This indents text and can be used to highlight useful information.^</td>
+      </tr>
+      <tr>
+        <td>Warning text (warning callout)</td>
+        <td>Put % before and after the text you want in the warning.</td>
+        <td>%This adds a warning icon and can be used to highlight something important.%</td>
+      </tr>
+      <tr>
+        <td>Contacts</td>
+        <td>Put $C on the lines before and after your contact details. Add 2 spaces at the end of each line within the contact details.</td>
+        <td>$C<br>
+        Email: contact.us@team.gov.uk  <br>
+        Telephone:01234 555666  <br>
+        Monday to Friday, 8am to 5pm  <br>
+        $C</td>
+      </tr>
+      <tr>
+        <td>Addresses</td>
+        <td>Put $A on the lines before and after your address. Add 2 spaces at the end of each line within the address.</td>
+        <td>$A<br>
+        Ministry of Justice  <br>
+        102 Petty France  <br>
+        London  <br>
+        SW1H 9AJ  <br>
+        $A</td>
+      </tr>
+    </tbody>
+  </table>
+  <p><a class="govuk-link" href="#top">Back to top</a></p>
+</section>
 <section class="content-section content-section--with-top-border">
-        <h2 id="welsh-translation" class="govuk-heading-m">Translating a form into Welsh</h2>
-        <p>It's possible to create a separate version of a form for Welsh-language users.</p>
-        <p>You will need to:</p>
-        <ul>
-        <li><a class="govuk-link" href="/contact">contact us</a> to create a copy of your form</li>
-        <li>arrange the translation yourself</li>
-        <li>update the copy of your form with the translated text</li>
-        <li>add links to the start pages of the English and Welsh forms allowing users to switch between languages</li>
-        <li>keep both versions in sync if you make any changes</li>
-        </ul>
-        <p>The MoJ Forms team maintains translations of wording present in the form's template, such as button text and error messages. When we create the Welsh version of your form, we ensure this content also appears in the appropriate language.</p>
-        <p>Following this approach, the 2 versions of your forms will be completely separate and users will be unable to switch between the languages during completion.</p>
-        <p><a class="govuk-link" href="#top">Back to top</a></p>
-      </section>
-        <!-- END CONTENT -->
-      </div>
-    </div>
-  </main>
-</div>
+  <h2 id="visibility" class="govuk-heading-m">Targeting content with visibility</h2>
+  <p>Visibility is what we call being able to show users different blocks of content based on their previous answers. With visibility, you can change or hide some of the content on the page for different users.</p>
+  <p>It's also a really powerful tool for creating <a class="govuk=link" href="https://gds.blog.gov.uk/2012/02/16/smart-answers-are-smart/">'smart answer' services</a> where you ask the user a series of questions and provide information tailored to their answers. Visibility allows you to use a single information page to serve dozens of different combinations of answers.</p>
+  <p>Visibility is a setting on all content areas - the text boxes that allow you to add paragraphs of content and use markdown formatting. These are on content pages, exit pages, the confirmation page and a number of other <a class="govuk-link" href="#page-type">page templates</a>.</p>
+  <p>Visibility allows you to set a content area to show:</p>
+  <ul>
+  <li>always (the default setting)</li>
+  <li>never</li>
+  <li>only if…</li>
+  </ul>
+  <p>With "only if…" you set the conditions under which the content area will show. For example, only show if a user answered yes to a previous question or selected a specific option. It works just like <a class="govuk-link" href="/branching/">branching</a>, only you are creating rules on a page rather than between pages. And as with branching, visibility rules can only be based on radio button or checkbox questions at the moment.</p>
+  <h3 class="govuk-heading-s">Setting a content area's visibility</h3>
+  <p>To set the visibility of a content area, click in the content area to highlight the component settings button (...) and click to open the menu. Select "show if…" to open the settings window and choose between the 3 options (show always, only if… or never).</p>
+  <p>When you select "only if…", the window will expand to allow you to input your conditions.</p>
+  <p>A condition consists of:</p>
+  <ul>
+  <li>the question that the visibility will be based on</li>
+  <li>an operator - such as 'is' or 'is not'</li>
+  <li>the user's answer</li>
+  </ul>
+  <p>For example, a condition could be:</p>
+  <ul>
+  <li>question - what is your favourite colour?</li>
+  <li>operator - is</li>
+  <li>answer - red</li>
+  </ul>
+  <p>In this example, the content area would only show to users who said red was their favourite colour.</p>
+  <p>A content area can have as many conditions as you need.</p>
+  <p>A page will show all content areas in the MoJ Forms editor and when you preview the individual page, regardless of visibility settings. That's because you need the relevant answers to previous questions for the settings to apply. To check how a page will appear to users, you will need to start your form from the beginning, using either the <a class="govuk-link" href="#preview">“preview form” feature</a> or when published to Test.</p>
+  <p><a class="govuk-link" href="#top">Back to top</a></p>
+</section>
+<section class="content-section content-section--with-top-border">
+  <h2 id="welsh-translation" class="govuk-heading-m">Translating a form into Welsh</h2>
+  <p>It's possible to create a separate version of a form for Welsh-language users.</p>
+  <p>You will need to:</p>
+  <ul>
+  <li><a class="govuk-link" href="/contact">contact us</a> to create a copy of your form</li>
+  <li>arrange the translation yourself</li>
+  <li>update the copy of your form with the translated text</li>
+  <li>add links to the start pages of the English and Welsh forms allowing users to switch between languages</li>
+  <li>keep both versions in sync if you make any changes</li>
+  </ul>
+  <p>The MoJ Forms team maintains translations of wording present in the form's template, such as button text and error messages. When we create the Welsh version of your form, we ensure this content also appears in the appropriate language.</p>
+  <p>Following this approach, the 2 versions of your forms will be completely separate and users will be unable to switch between the languages during completion.</p>
+  <p><a class="govuk-link" href="#top">Back to top</a></p>
+</section>
+

--- a/source/data-protection.html.erb
+++ b/source/data-protection.html.erb
@@ -3,69 +3,63 @@ title: Data protection and privacy
 heading: Data protection and privacy
 category: user-guide
 order: 6
+layout: user_guide
 ---
-<div class="govuk-width-container">
-  <main class="govuk-main-wrapper govuk-body" id="main-content" role="main">
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-one-quarter">
-        <%= partial "user_nav" %>
-      </div>
-      <div class="govuk-grid-column-three-quarters">
-        <h1 class="govuk-heading-l"><%= current_page.data.heading %></h1>
-        <!-- START CONTENT -->
-        <p class="govuk-body-l">How to ensure your form is compliant with data protection policies and procedures and keep your users’ data secure.</p>
-        <h2 class="govuk-heading-m">Contents</h2>
-        <%= partial "toc", locals: { links: { 
-          'responsibilities': "Your data protection responsibilities",
-          'registeractivity': "Registering your data processing activity",
-          'designingtheform': "Designing and building your form",
-          'privacynotice': "Preparing a privacy notice",
-          'formsecurity': "How your forms are secured",
-          'sessionduration': "Session duration",
-        }} %>
-        <section class="content-section content-section--with-top-border">
-        <h2 id="responsibilities" class="govuk-heading-m">Your data protection responsibilities</h2>
-        <p>As you design a new form or make any substantial changes to an existing form, you will need to:</p>
-        <ol>
-        <li><a class="govuk-link" href="#registeractivity">register your data processing activity</a> with the appropriate data protection team</li>
-        <li><a class="govuk-link" href="#designingtheform">think about how and why you are asking for personal information</a></li>
-        <li><a class="govuk-link" href="#privacynotice">prepare a privacy notice</a> to include in the footer of your form</li>
-        </ol>
-        <p>These steps will help ensure that you comply with standards and best practice around the lawful capture and ongoing protection of any personal data that you collect with your forms. Your responsibilities include:</p>
-        <ul>
-        <li>ensuring that you only collect the minimum amount of personal data necessary and relevant for the purposes of the activity</li>
-        <li>making it as easy as possible for users to understand why you are collecting personal data and how you will use it</li>
-        <li>establishing the most appropriate lawful basis for the personal data capture</li>
-        <li>the security and safe storage of the personal data captured after it has been submitted and who is authorised to view or access it</li>
-        <li>ensuring that the personal data is only used for the purposes for which it is captured</li>
-        <li>destroying or de-identifying the personal data once the purpose for which it has been captured expires, in line with your organisation's retention schedules</li>
-        </ul>
-        <p>For more information on your responsibilities, read the guide to <a class="govuk-link" href="https://intranet.justice.gov.uk/guidance/knowledge-information/protecting-information/privacy-reform/">data protection</a> on the MoJ intranet or contact your organisation's data protection team.</p>
-        <p><a class="govuk-link" href="#top">Back to top</a></p>
-      </section>
-       <section class="content-section content-section--with-top-border">
-        <h2 id="registeractivity" class="govuk-heading-m">Registering your data processing activity</h2>
-        <p>If you are planning on using a form to collect personal information, you also need to consider how you will use and manage that information. Collectively, this is known as a data processing activity.</p>
-        </p>All data processing activities should go through a data protection impact assessment (DPIA) screening. This will help identify and minimise any data protection risks involved and ensure that the activity is registered with the data protection team.</p>
-        <p>You should do this if you are making significant changes to an existing data processing activity as well when establishing a new one.</p>
-        <p>If MoJ is your data controller, you will need to contact your <a class="govuk-link" href="https://intranet.justice.gov.uk/guidance/knowledge-information/protecting-information/information-assurance-roles/">information assurance lead</a> or the data protection team (<a class="govuk-link" href="mailto:dataprotection@justice.gov.uk">dataprotection@justice.gov.uk</a>) to initiate this process.</p>
-        <p>The process may vary in departments and agencies that use a different data controller. Contact your organisation’s data protection team for guidance.</p>
-        <p><a class="govuk-link" href="#top">Back to top</a></p>
-      </section>
-      <section class="content-section content-section--with-top-border">
-    <h2 id="designingtheform" class="govuk-heading-m">Designing and building your form</h2>
-    <p>When designing your form, ensure that:</p>
-    <ul>
+<h1 class="govuk-heading-l"><%= current_page.data.heading %></h1>
+
+<p class="govuk-body-l">How to ensure your form is compliant with data protection policies and procedures and keep your users’ data secure.</p>
+<h2 class="govuk-heading-m">Contents</h2>
+<%= partial "toc", locals: { links: { 
+  'responsibilities': "Your data protection responsibilities",
+  'registeractivity': "Registering your data processing activity",
+  'designingtheform': "Designing and building your form",
+  'privacynotice': "Preparing a privacy notice",
+  'formsecurity': "How your forms are secured",
+  'sessionduration': "Session duration",
+}} %>
+<section class="content-section content-section--with-top-border">
+  <h2 id="responsibilities" class="govuk-heading-m">Your data protection responsibilities</h2>
+  <p>As you design a new form or make any substantial changes to an existing form, you will need to:</p>
+  <ol>
+    <li><a class="govuk-link" href="#registeractivity">register your data processing activity</a> with the appropriate data protection team</li>
+    <li><a class="govuk-link" href="#designingtheform">think about how and why you are asking for personal information</a></li>
+    <li><a class="govuk-link" href="#privacynotice">prepare a privacy notice</a> to include in the footer of your form</li>
+  </ol>
+  <p>These steps will help ensure that you comply with standards and best practice around the lawful capture and ongoing protection of any personal data that you collect with your forms. Your responsibilities include:</p>
+  <ul>
+    <li>ensuring that you only collect the minimum amount of personal data necessary and relevant for the purposes of the activity</li>
+    <li>making it as easy as possible for users to understand why you are collecting personal data and how you will use it</li>
+    <li>establishing the most appropriate lawful basis for the personal data capture</li>
+    <li>the security and safe storage of the personal data captured after it has been submitted and who is authorised to view or access it</li>
+    <li>ensuring that the personal data is only used for the purposes for which it is captured</li>
+    <li>destroying or de-identifying the personal data once the purpose for which it has been captured expires, in line with your organisation's retention schedules</li>
+  </ul>
+  <p>For more information on your responsibilities, read the guide to <a class="govuk-link" href="https://intranet.justice.gov.uk/guidance/knowledge-information/protecting-information/privacy-reform/">data protection</a> on the MoJ intranet or contact your organisation's data protection team.</p>
+  <p><a class="govuk-link" href="#top">Back to top</a></p>
+</section>
+<section class="content-section content-section--with-top-border">
+  <h2 id="registeractivity" class="govuk-heading-m">Registering your data processing activity</h2>
+  <p>If you are planning on using a form to collect personal information, you also need to consider how you will use and manage that information. Collectively, this is known as a data processing activity.</p>
+  </p>All data processing activities should go through a data protection impact assessment (DPIA) screening. This will help identify and minimise any data protection risks involved and ensure that the activity is registered with the data protection team.</p>
+  <p>You should do this if you are making significant changes to an existing data processing activity as well when establishing a new one.</p>
+  <p>If MoJ is your data controller, you will need to contact your <a class="govuk-link" href="https://intranet.justice.gov.uk/guidance/knowledge-information/protecting-information/information-assurance-roles/">information assurance lead</a> or the data protection team (<a class="govuk-link" href="mailto:dataprotection@justice.gov.uk">dataprotection@justice.gov.uk</a>) to initiate this process.</p>
+  <p>The process may vary in departments and agencies that use a different data controller. Contact your organisation’s data protection team for guidance.</p>
+  <p><a class="govuk-link" href="#top">Back to top</a></p>
+</section>
+<section class="content-section content-section--with-top-border">
+  <h2 id="designingtheform" class="govuk-heading-m">Designing and building your form</h2>
+  <p>When designing your form, ensure that:</p>
+  <ul>
     <li>you only ask for the information you need to perform your activity - for example, to perform a data protection check or contact the user in the event of a query</li>
     <li>you are clear with users why you are asking for something</li>
     <li>users can understand what you will do with their information</li>
-    </ul>
-    <p>To help you work out what to ask, you can carry out a <a class="govuk-link" href="https://www.uxmatters.com/mt/archives/2010/06/the-question-protocol-how-to-make-sure-every-form-field-is-necessary.php">question protocol</a>.</p>
-    <p>You should also <a class="govuk-link" href="#privacynotice">prepare a privacy notice</a>.</p>
-    <p>For more guidance on designing and building your form, read the <a class="govuk-link" href="https://www.gov.uk/service-manual/design/collecting-personal-information-from-users">Service Manual guidelines on collecting personal information</a>.</p>
-    <p><a class="govuk-link" href="#top">Back to top</a></p>
-  </section>
-  <section class="content-section content-section--with-top-border">
+  </ul>
+  <p>To help you work out what to ask, you can carry out a <a class="govuk-link" href="https://www.uxmatters.com/mt/archives/2010/06/the-question-protocol-how-to-make-sure-every-form-field-is-necessary.php">question protocol</a>.</p>
+  <p>You should also <a class="govuk-link" href="#privacynotice">prepare a privacy notice</a>.</p>
+  <p>For more guidance on designing and building your form, read the <a class="govuk-link" href="https://www.gov.uk/service-manual/design/collecting-personal-information-from-users">Service Manual guidelines on collecting personal information</a>.</p>
+  <p><a class="govuk-link" href="#top">Back to top</a></p>
+</section>
+<section class="content-section content-section--with-top-border">
   <h2 id="privacynotice" class="govuk-heading-m">Preparing a privacy notice</h2>
   <p>All forms are created with a privacy page in the footer section which comes pre-populated with a template privacy notice. There are sections in the notice that you must fill in with details specific to your team and form. These are indicated in square brackets - [like this].</p>
   <p>If you are updating an existing form, you will need to check your privacy notice against the latest version of the template as some sections may have changed.</p>
@@ -75,7 +69,7 @@ order: 6
   <p>If you work in a department or agency with a different data controller, your privacy notice will need to include different details and may need a different template. Contact your organisation’s data protection team for guidance.</p>
   <p><a class="govuk-link" href="#top">Back to top</a></p>
 </section>
-  <section class="content-section content-section--with-top-border">
+<section class="content-section content-section--with-top-border">
   <h2 id="formsecurity" class="govuk-heading-m">How your forms are secured</h2>
   <p>The Digital and Technology team is responsible for the technical security of the MoJ Forms platform.</p>
   <p>We take every precaution with user data as users enter it. User data is saved during a session and protected with high levels of encryption (we use <a class="govuk-link" href="https://en.wikipedia.org/wiki/Advanced_Encryption_Standard">AES 256-bit encryption</a>).</p>
@@ -86,21 +80,16 @@ order: 6
   <p><a class="govuk-link" href="#top">Back to top</a></p>
 </section>
 <section class="content-section content-section--with-top-border">
-<h2 id="sessionduration" class="govuk-heading-m">Session duration</h2>
-<p>For security reasons, MoJ Forms has a session duration of 30 minutes. This is refreshed every time a user enters some information or interacts with a button or feature on the page so they can take as long as they need to complete the form.</p>
-<p>If nothing happens on a page for 25 minutes, the form will warn the user that the form is about to reset. If the user acknowledges the message, the session will refresh to 30 minutes. If nothing continues to happen for another 5 minutes, the form will reset. Any information entered into the form up to that point will be deleted and the user will need to start again.</p>
-<p>To minimise the risk of users losing their progress, you could consider:</p>
-<ul>
-<li>letting users know on the start page what information they will need to hand</li>
-<li>structuring your form to ask <a class="govuk-link" href="https://designnotes.blog.gov.uk/2015/07/03/one-thing-per-page/">one thing per page</a></li>
-<li>allowing users to <a class="govuk-link" href="/building-and-editing/#file-upload">upload files</a> if you require a detailed answer to a question</li>
-<li>limiting the length of textarea questions using the <a class="govuk-link" href="/building-and-editing/#validation">validation settings</a></li>
-<li>enabling <a class="govuk-link" href="/settings/#save-for-later">'save for later'</a>, which allows users to save their progress on a form a return to complete it later</li>
-</ul>
-<p><a class="govuk-link" href="#top">Back to top</a></p>
+  <h2 id="sessionduration" class="govuk-heading-m">Session duration</h2>
+  <p>For security reasons, MoJ Forms has a session duration of 30 minutes. This is refreshed every time a user enters some information or interacts with a button or feature on the page so they can take as long as they need to complete the form.</p>
+  <p>If nothing happens on a page for 25 minutes, the form will warn the user that the form is about to reset. If the user acknowledges the message, the session will refresh to 30 minutes. If nothing continues to happen for another 5 minutes, the form will reset. Any information entered into the form up to that point will be deleted and the user will need to start again.</p>
+  <p>To minimise the risk of users losing their progress, you could consider:</p>
+  <ul>
+    <li>letting users know on the start page what information they will need to hand</li>
+    <li>structuring your form to ask <a class="govuk-link" href="https://designnotes.blog.gov.uk/2015/07/03/one-thing-per-page/">one thing per page</a></li>
+    <li>allowing users to <a class="govuk-link" href="/building-and-editing/#file-upload">upload files</a> if you require a detailed answer to a question</li>
+    <li>limiting the length of textarea questions using the <a class="govuk-link" href="/building-and-editing/#validation">validation settings</a></li>
+    <li>enabling <a class="govuk-link" href="/settings/#save-for-later">'save for later'</a>, which allows users to save their progress on a form a return to complete it later</li>
+  </ul>
+  <p><a class="govuk-link" href="#top">Back to top</a></p>
 </section>
-        <!-- END CONTENT -->
-      </div>
-    </div>
-  </main>
-</div>

--- a/source/getting-started.html.erb
+++ b/source/getting-started.html.erb
@@ -3,122 +3,112 @@ title: Getting started
 heading: Getting started
 category: user-guide
 order: 2
+layout: user_guide
 ---
-<div class="govuk-width-container">
-  <main class="govuk-main-wrapper govuk-body" id="main-content" role="main">
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-one-quarter">
-        <%= partial "user_nav" %>
-      </div>
-      <div class="govuk-grid-column-three-quarters">
-        <h1 class="govuk-heading-l"><%= current_page.data.heading%></h1>
-        <!-- START CONTENT -->
-        <p class="govuk-body-l">Everything you need to know about getting started with MoJ Forms and planning a form.</p>
-        <h2 class="govuk-heading-m">Contents</h2>
-        <%= partial "toc", locals: { links: { 
-          'good-forms': 'What makes a good form',
-          planning: 'Planning your form',
-          'security-classifications': 'Security classifications for your form',
-          timescales: 'Timescales and engagement',
-          assessment: 'Getting your form assessed',
-          govuk: 'Getting on GOV.UK',
-        }} %>
-      <section class="content-section content-section--with-top-border">
-          <h2 id="good-forms" class="govuk-heading-m">What makes a good form</h2>
-        <p>Forms built with MoJ Forms should aim to meet the GOV.UK <a class="govuk-link" href="https://www.gov.uk/service-manual/service-standard">Service Standard</a>. This is a set of principles that helps government teams create and run high-quality services.</p> 
-        <p>Not all of the principles will be relevant and some of them have been taken care of by MoJ Forms but you should still consider how they can be applied to your project. In particular, it is important that you:</p>
-        <ul>
-        <li>understand your users' needs</li>
-        <li>make your form simple to use</li>
-        <li>make sure everyone can use your form</li>
-        </ul>
-        <p>The <a class="govuk-link" href="https://www.gov.uk/service-manual">Service Manual</a> includes a lot of simple, clear advice to help you create a form that meets the Service Standard. The section on <a class="govuk-link" href="https://www.gov.uk/service-manual/design/form-structure">structuring forms</a> will be particularly useful.</p>
-        <p><a class="govuk-link" href="#top">Back to top</a></p>
-      </section>
-      <section class="content-section content-section--with-top-border">
-      <h2 id="planning" class="govuk-heading-m">Planning your form</h2>
-      <p>We have designed MoJ Forms to be quick and easy to use but it helps to plan your form in advance. Before you start building your form, think about:</p>
-      <ul>
-      <li>what information you need to ask for - creating a <a class="govuk=link" href="https://www.uxmatters.com/mt/archives/2010/06/the-question-protocol-how-to-make-sure-every-form-field-is-necessary.php">question protocol</a> can help you with this</li>
-      <li>how to order your questions - for example, put questions that help users work out if they are eligible for your service at the beginning</li>
-      <li>how to group your questions - forms work best when you ask <a class="govuk-link" href="https://designnotes.blog.gov.uk/2015/07/03/one-thing-per-page/">one thing per page</a></li>
-      <li>which <a class="govuk-link" href="/building-and-editing/#page-type">question format</a> to use for each question</li>
-      <li>where you might need branches to divert users around questions they don't need to answer</li>
-      </ul>
-      <p>For more help with planning, read the <a class="govuk-link" href="https://www.gov.uk/service-manual/design/form-structure">Service Manual chapter on structuring forms</a>.</p>
-      <p>Also refer to the <a class="govuk-link" href="https://design-system.service.gov.uk/">GOV.UK Design System</a> for advice and guidance on how best to use the specific question formats.</p>
-      <p><a class="govuk-link" href="#top">Back to top</a></p>
-    </section>
-    <section class="content-section content-section--with-top-border">
-    <h2 id="security-classifications" class="govuk-heading-m">Security classifications for your form</h2>
-    <p>MoJ Forms can be used only for information classed up to SENSITIVE under the <a class="govuk-link" href="https://www.gov.uk/government/publications/government-security-classifications/government-security-classifications-policy-html">Government Security Classifications Policy</a>.</p>
-    <p>The policy is a framework for protecting government information against compromise, loss or incorrect disclosure. Any information that is created, processed, sent or received as a part of your work for the government falls within the policy.</p>
-    <p>The OFFICIAL classification covers the majority of information that is created, processed, sent or received in the public sector and by partner organisations, which could cause no more than moderate damage if compromised.</p>
-    <p>All data received from a form is labelled OFFICIAL-SENSITIVE. The additional -SENSITIVE marking indicates that the information is not intended for public release and that it is of at least some interest to threat actors (internal or external), activists or the media. This may not always apply, depending on the nature of your form, but this extra marking ensures that all relevant data is covered.</p>
-    <p>MoJ Forms should not be used if any of the information being collected has the potential to fall under the SECRET or TOP SECRET classifications.</p>
-    <p><a class="govuk-link" href="#top">Back to top</a></p>
-  </section>
-    <section class="content-section content-section--with-top-border">
-    <h2 id="timescales" class="govuk-heading-m">Timescales and engagement</h2>
-    <p>It's possible to build a test form in minutes using MoJ Forms but getting a form ready for live can take a lot longer. As well as the usual time it might take to review and sign off your form, there are a number of things we recommend you consider and plan in advance.</p>
-    <h3 class="govuk-heading-s">Data protection</h3>
-    </p>You should contact your information assurance lead or local data protection team as early as possible to discuss whether your form requires a data protection impact assessment (DPIA). This will help identify and minimise any data protection risks involved and ensure that the activity is registered with the data protection team.</p>
-    <p>Nearer to your publication date, you will also need to prepare a privacy notice.</p>
-    <p>See the section on <a class="govuk-link" href="/data-protection">data protection and privacy</a> for details.</p>
-    <h3 class="govuk-heading-s">Accessibility</h3>
-    <p>Public sector accessibility regulations require all forms to be accessible and have an accessibility statement. This means making your content and design clear and simple enough so that most people can use it without needing to adapt it, while supporting those who do need to adapt things.</p>
-    <p>We have taken care of a lot of the requirements for you by making MoJ page designs fully accessible and providing a template for your accessibility statement. But you will still need to conduct a basic accessibility check and complete the statement with your own details.</p>
-    <p>Learn more in the <a class="govuk-link" href="/accessibility">accessibility</a> section.</p>
-    <h3 class="govuk-heading-s">Taking payments</h3>
-    <p>MoJ Forms can help you take payments from users by connecting your form with GOV.UK Pay using <a class="govuk-link" href="/settings/#payment-links">payment links</a>. If you are new to GOV.UK Pay, this will take time to set up.</p>
-    <p>You can create a GOV.UK Pay account and set up a test payment link in just a few minutes but it may be several months before you are ready to take payments. This depends on the payment service provider arrangements in your area. For example, MoJ, HMCTS and HMPPS all have separate agreements with the Government Banking Service.</p>
-    <h3 class="govuk-heading-s">Email accounts</h3>
-    <p>You may need to set up several new team email accounts for use with MoJ Forms:</p>
-    <ul>
-    <li>to collect submissions from your form</li>
-    <li>to use as the reply address on confirmation emails</li>
-    </ul>
-    <p>These can be the same or different and will need to be verified as you are building and setting up your form.</p>
 
-    <h3 class="govuk-heading-s">Welsh language support</h3>
-    <p>UK government departments that provide services in Wales are required to treat the Welsh and English languages equally. That means you may need to translate your form into Welsh and provide support to users in Welsh.</p>
-    <p>MoJ has several Welsh Language Schemes which explain our policy on translating and providing services in Welsh: 
-    <ul>
-    <li><a class="govuk-link" href="https://www.gov.uk/government/publications/moj-welsh-language-scheme-2018">MoJ Welsh language scheme 2018</a></li>
-    <li><a class="govuk-link" href="https://www.gov.uk/government/publications/hmpps-welsh-language-scheme-2020-to-2023">HMPPS Welsh language scheme 2020 to 2023</a></li>
-    <li><a class="govuk-link" href="https://www.gov.uk/government/organisations/hm-courts-and-tribunals-service/about/welsh-language-scheme">HMCTS Welsh language scheme</a></li>
-    <li><a class="govuk-link" href="https://www.gov.uk/government/organisations/criminal-injuries-compensation-authority/about/welsh-language-scheme">CICA Welsh language scheme</a></li>
-    <li><a class="govuk-link" href="https://www.gov.uk/government/organisations/office-of-the-public-guardian/about/welsh-language-scheme">OPG Welsh language scheme</a></li>
-    </ul>
-    <p>When deciding whether to translate a form, follow your agency's Welsh language scheme and look for evidence of a user need, such as high volumes of Welsh users or requests for translations from Welsh-language speakers.</p>
-    <p>You will need to source your own translations and enter these manually into a separate version of your form. See <a class="govuk-link" href="/building-and-editing#welsh-translation">Translating a form into Welsh</a> for details. You may also need to consider processes and resources for handling and responding to users in Welsh.</p>
-    <p>Your local GOV.UK publishing team will be able to advise you on sourcing translations.</p>
-    <h3 class="govuk-heading-s">Unlocking the ability to publish to Live</h3>
-    <p>When you think your form is ready, you will need to apply to <a class="govuk-link" href="/testing-and-publishing/#final-check">unlock the ability to publish to Live</a>. This can take up to 3 working days and may highlight the need for changes to the form.</p>
-    <p><a class="govuk-link" href="#top">Back to top</a></p>
-  </section>
-  <section class="content-section content-section--with-top-border">
-   <h2 id="assessment" class="govuk-heading-m">Getting your form assessed</h2>
-   <p>Government digital services usually go through a service assessment. This is a process managed by the Central Digital and Data Office (CDDO) and each government department to ensure all government services are built to the same standard.</p>
-   <p>Forms built with a form-building service like MoJ Forms are an exception. Your form will only need to go through a service assessment if one or more of the following apply:</p> 
-   <ul>
-   <li>it’s likely to handle more than 10,000 transactions per year</li>
-   <li>it supports vulnerable people, people in danger or responses to natural disasters</li>
-   <li>it helps keep government accountable, and is required by law or regulation</li>
-   <li>it’s likely to transfer more than £1 million each year to members of the public or organisations</li>
-   </ul>
-   <p>If you think any of these might apply to your service, contact your local service assessment lead. See <a class="govuk-link" href="https://www.gov.uk/service-manual/service-assessments/check-if-need-to-meet-service-standard">Check if you need to meet the Service Standard or get an assessment</a> for details.</p>
-   <p>If none of these apply, you won't need a service assessment.</p>
-   <p><a class="govuk-link" href="#top">Back to top</a></p>
-  </section>
-  <section class="content-section content-section--with-top-border">
+<h1 class="govuk-heading-l"><%= current_page.data.heading%></h1>
+<p class="govuk-body-l">Everything you need to know about getting started with MoJ Forms and planning a form.</p>
+<h2 class="govuk-heading-m">Contents</h2>
+<%= partial "toc", locals: { links: { 
+  'good-forms': 'What makes a good form',
+  planning: 'Planning your form',
+  'security-classifications': 'Security classifications for your form',
+  timescales: 'Timescales and engagement',
+  assessment: 'Getting your form assessed',
+  govuk: 'Getting on GOV.UK',
+}} %>
+<section class="content-section content-section--with-top-border">
+  <h2 id="good-forms" class="govuk-heading-m">What makes a good form</h2>
+  <p>Forms built with MoJ Forms should aim to meet the GOV.UK <a class="govuk-link" href="https://www.gov.uk/service-manual/service-standard">Service Standard</a>. This is a set of principles that helps government teams create and run high-quality services.</p> 
+  <p>Not all of the principles will be relevant and some of them have been taken care of by MoJ Forms but you should still consider how they can be applied to your project. In particular, it is important that you:</p>
+  <ul>
+  <li>understand your users' needs</li>
+  <li>make your form simple to use</li>
+  <li>make sure everyone can use your form</li>
+  </ul>
+  <p>The <a class="govuk-link" href="https://www.gov.uk/service-manual">Service Manual</a> includes a lot of simple, clear advice to help you create a form that meets the Service Standard. The section on <a class="govuk-link" href="https://www.gov.uk/service-manual/design/form-structure">structuring forms</a> will be particularly useful.</p>
+  <p><a class="govuk-link" href="#top">Back to top</a></p>
+</section>
+<section class="content-section content-section--with-top-border">
+  <h2 id="planning" class="govuk-heading-m">Planning your form</h2>
+  <p>We have designed MoJ Forms to be quick and easy to use but it helps to plan your form in advance. Before you start building your form, think about:</p>
+  <ul>
+  <li>what information you need to ask for - creating a <a class="govuk=link" href="https://www.uxmatters.com/mt/archives/2010/06/the-question-protocol-how-to-make-sure-every-form-field-is-necessary.php">question protocol</a> can help you with this</li>
+  <li>how to order your questions - for example, put questions that help users work out if they are eligible for your service at the beginning</li>
+  <li>how to group your questions - forms work best when you ask <a class="govuk-link" href="https://designnotes.blog.gov.uk/2015/07/03/one-thing-per-page/">one thing per page</a></li>
+  <li>which <a class="govuk-link" href="/building-and-editing/#page-type">question format</a> to use for each question</li>
+  <li>where you might need branches to divert users around questions they don't need to answer</li>
+  </ul>
+  <p>For more help with planning, read the <a class="govuk-link" href="https://www.gov.uk/service-manual/design/form-structure">Service Manual chapter on structuring forms</a>.</p>
+  <p>Also refer to the <a class="govuk-link" href="https://design-system.service.gov.uk/">GOV.UK Design System</a> for advice and guidance on how best to use the specific question formats.</p>
+  <p><a class="govuk-link" href="#top">Back to top</a></p>
+</section>
+<section class="content-section content-section--with-top-border">
+  <h2 id="security-classifications" class="govuk-heading-m">Security classifications for your form</h2>
+  <p>MoJ Forms can be used only for information classed up to SENSITIVE under the <a class="govuk-link" href="https://www.gov.uk/government/publications/government-security-classifications/government-security-classifications-policy-html">Government Security Classifications Policy</a>.</p>
+  <p>The policy is a framework for protecting government information against compromise, loss or incorrect disclosure. Any information that is created, processed, sent or received as a part of your work for the government falls within the policy.</p>
+  <p>The OFFICIAL classification covers the majority of information that is created, processed, sent or received in the public sector and by partner organisations, which could cause no more than moderate damage if compromised.</p>
+  <p>All data received from a form is labelled OFFICIAL-SENSITIVE. The additional -SENSITIVE marking indicates that the information is not intended for public release and that it is of at least some interest to threat actors (internal or external), activists or the media. This may not always apply, depending on the nature of your form, but this extra marking ensures that all relevant data is covered.</p>
+  <p>MoJ Forms should not be used if any of the information being collected has the potential to fall under the SECRET or TOP SECRET classifications.</p>
+  <p><a class="govuk-link" href="#top">Back to top</a></p>
+</section>
+<section class="content-section content-section--with-top-border">
+  <h2 id="timescales" class="govuk-heading-m">Timescales and engagement</h2>
+  <p>It's possible to build a test form in minutes using MoJ Forms but getting a form ready for live can take a lot longer. As well as the usual time it might take to review and sign off your form, there are a number of things we recommend you consider and plan in advance.</p>
+  <h3 class="govuk-heading-s">Data protection</h3>
+  </p>You should contact your information assurance lead or local data protection team as early as possible to discuss whether your form requires a data protection impact assessment (DPIA). This will help identify and minimise any data protection risks involved and ensure that the activity is registered with the data protection team.</p>
+  <p>Nearer to your publication date, you will also need to prepare a privacy notice.</p>
+  <p>See the section on <a class="govuk-link" href="/data-protection">data protection and privacy</a> for details.</p>
+  <h3 class="govuk-heading-s">Accessibility</h3>
+  <p>Public sector accessibility regulations require all forms to be accessible and have an accessibility statement. This means making your content and design clear and simple enough so that most people can use it without needing to adapt it, while supporting those who do need to adapt things.</p>
+  <p>We have taken care of a lot of the requirements for you by making MoJ page designs fully accessible and providing a template for your accessibility statement. But you will still need to conduct a basic accessibility check and complete the statement with your own details.</p>
+  <p>Learn more in the <a class="govuk-link" href="/accessibility">accessibility</a> section.</p>
+  <h3 class="govuk-heading-s">Taking payments</h3>
+  <p>MoJ Forms can help you take payments from users by connecting your form with GOV.UK Pay using <a class="govuk-link" href="/settings/#payment-links">payment links</a>. If you are new to GOV.UK Pay, this will take time to set up.</p>
+  <p>You can create a GOV.UK Pay account and set up a test payment link in just a few minutes but it may be several months before you are ready to take payments. This depends on the payment service provider arrangements in your area. For example, MoJ, HMCTS and HMPPS all have separate agreements with the Government Banking Service.</p>
+  <h3 class="govuk-heading-s">Email accounts</h3>
+  <p>You may need to set up several new team email accounts for use with MoJ Forms:</p>
+  <ul>
+  <li>to collect submissions from your form</li>
+  <li>to use as the reply address on confirmation emails</li>
+  </ul>
+  <p>These can be the same or different and will need to be verified as you are building and setting up your form.</p>
+
+  <h3 class="govuk-heading-s">Welsh language support</h3>
+  <p>UK government departments that provide services in Wales are required to treat the Welsh and English languages equally. That means you may need to translate your form into Welsh and provide support to users in Welsh.</p>
+  <p>MoJ has several Welsh Language Schemes which explain our policy on translating and providing services in Welsh: 
+  <ul>
+  <li><a class="govuk-link" href="https://www.gov.uk/government/publications/moj-welsh-language-scheme-2018">MoJ Welsh language scheme 2018</a></li>
+  <li><a class="govuk-link" href="https://www.gov.uk/government/publications/hmpps-welsh-language-scheme-2020-to-2023">HMPPS Welsh language scheme 2020 to 2023</a></li>
+  <li><a class="govuk-link" href="https://www.gov.uk/government/organisations/hm-courts-and-tribunals-service/about/welsh-language-scheme">HMCTS Welsh language scheme</a></li>
+  <li><a class="govuk-link" href="https://www.gov.uk/government/organisations/criminal-injuries-compensation-authority/about/welsh-language-scheme">CICA Welsh language scheme</a></li>
+  <li><a class="govuk-link" href="https://www.gov.uk/government/organisations/office-of-the-public-guardian/about/welsh-language-scheme">OPG Welsh language scheme</a></li>
+  </ul>
+  <p>When deciding whether to translate a form, follow your agency's Welsh language scheme and look for evidence of a user need, such as high volumes of Welsh users or requests for translations from Welsh-language speakers.</p>
+  <p>You will need to source your own translations and enter these manually into a separate version of your form. See <a class="govuk-link" href="/building-and-editing#welsh-translation">Translating a form into Welsh</a> for details. You may also need to consider processes and resources for handling and responding to users in Welsh.</p>
+  <p>Your local GOV.UK publishing team will be able to advise you on sourcing translations.</p>
+  <h3 class="govuk-heading-s">Unlocking the ability to publish to Live</h3>
+  <p>When you think your form is ready, you will need to apply to <a class="govuk-link" href="/testing-and-publishing/#final-check">unlock the ability to publish to Live</a>. This can take up to 3 working days and may highlight the need for changes to the form.</p>
+  <p><a class="govuk-link" href="#top">Back to top</a></p>
+</section>
+<section class="content-section content-section--with-top-border">
+  <h2 id="assessment" class="govuk-heading-m">Getting your form assessed</h2>
+  <p>Government digital services usually go through a service assessment. This is a process managed by the Central Digital and Data Office (CDDO) and each government department to ensure all government services are built to the same standard.</p>
+  <p>Forms built with a form-building service like MoJ Forms are an exception. Your form will only need to go through a service assessment if one or more of the following apply:</p> 
+  <ul>
+  <li>it’s likely to handle more than 10,000 transactions per year</li>
+  <li>it supports vulnerable people, people in danger or responses to natural disasters</li>
+  <li>it helps keep government accountable, and is required by law or regulation</li>
+  <li>it’s likely to transfer more than £1 million each year to members of the public or organisations</li>
+  </ul>
+  <p>If you think any of these might apply to your service, contact your local service assessment lead. See <a class="govuk-link" href="https://www.gov.uk/service-manual/service-assessments/check-if-need-to-meet-service-standard">Check if you need to meet the Service Standard or get an assessment</a> for details.</p>
+  <p>If none of these apply, you won't need a service assessment.</p>
+  <p><a class="govuk-link" href="#top">Back to top</a></p>
+</section>
+<section class="content-section content-section--with-top-border">
   <h2 id="govuk" class="govuk-heading-m">Getting on GOV.UK</h2>
   <p>If you want to link to your form from GOV.UK, you will need to talk to your local GOV.UK publishing team. They will help you decide where the form should sit and help you with any guidance content that may be required around it. You will also need to <a class="govuk-link" href="/building-and-editing#start-page">decide where your start page is going to sit</a>.</p>
   <p>If your form is aimed at members of the public and will sit under services and information (sometimes called 'mainstream' content), they will need to raise a request with the Government Digital Service (GDS) to make the necessary changes. This could take more time.</p>
   <p><a class="govuk-link" href="#top">Back to top</a></p>
- </section>
-        <!-- END CONTENT -->
-      </div>
-    </div>
-  </main>
-</div>
+</section>
+

--- a/source/layouts/user_guide.erb
+++ b/source/layouts/user_guide.erb
@@ -1,0 +1,14 @@
+<% wrap_layout :layout do %>
+<div class="govuk-width-container">
+  <div class="govuk-main-wrapper govuk-body">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-one-quarter">
+        <%= partial "user_nav" %>
+      </div>
+      <main class="govuk-grid-column-three-quarters" id="main-content" role="main">
+        <%= yield %>
+      </main>
+    </div>
+  </div>
+</div>
+<% end %>

--- a/source/settings.html.erb
+++ b/source/settings.html.erb
@@ -3,240 +3,228 @@ title: Settings
 heading: Settings
 category: user-guide
 order: 7
+layout: user_guide
 ---
-<div class="govuk-width-container">
-  <main class="govuk-main-wrapper govuk-body" id="main-content" role="main">
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-one-quarter">
-        <%= partial "user_nav" %>
-      </div>
-      <div class="govuk-grid-column-three-quarters">
-        <h1 class="govuk-heading-l"><%= current_page.data.heading %></h1>
-        <!-- START CONTENT -->
-        <p class="govuk-body-l">Enable optional features such as save for later and Google Analytics and configure how you receive information when users submit their forms.</p>
-        <h2 class="govuk-heading-m">Contents</h2>
-        <%= partial "toc", locals: { links: { 
-'change-name': "Changing your form's name and URL",
-'google-analytics': "Setting up Google Analytics",
-'save-for-later': "Enabling users to save their progress on a form",
-'email-settings': "Collecting information by email",
-'confirmation-email': "Sending users a confirmation email",
-'references': "Providing users with reference numbers",
-'payment-links': "Taking payments through GOV.UK Pay",
-'transfer-form': "Transferring your form to another user",
+<h1 class="govuk-heading-l"><%= current_page.data.heading %></h1>
+<p class="govuk-body-l">Enable optional features such as save for later and Google Analytics and configure how you receive information when users submit their forms.</p>
+<h2 class="govuk-heading-m">Contents</h2>
+<%= partial "toc", locals: { links: { 
+  'change-name': "Changing your form's name and URL",
+  'google-analytics': "Setting up Google Analytics",
+  'save-for-later': "Enabling users to save their progress on a form",
+  'email-settings': "Collecting information by email",
+  'confirmation-email': "Sending users a confirmation email",
+  'references': "Providing users with reference numbers",
+  'payment-links': "Taking payments through GOV.UK Pay",
+  'transfer-form': "Transferring your form to another user",
 }} %>
-        <section class="content-section content-section--with-top-border">
-        <h2 id="change-name" class="govuk-heading-m">Changing your form's name and URL</h2>
-        <p>You can review and update both your form's name and URL in settings. Go to: Settings > Form name and URL</p>
-        <p>You can change your form's name at any time but you can only change the URL up until you have published your form to Live. After this point, the option is no longer available in settings. This is because changing a Live form's URL can cause problems for users if they have bookmarked the old form or are using an old link. If you need to change a Live form's URL, <a class="govuk-link" href="/contact">contact us to discuss it</a>.</p>
-        <p>You will need to publish your form for any changes to take effect. If you change the URL of a form that has already been published to Test, any links to the old URL will stop working after you publish the new URL.</p>
-        <h3 class="govuk-heading-s">Things to consider when changing the name</h3>
-        <p>The new name should continue to follow the guidelines for <a class="govuk-link" href="/building-and-editing/#form-name">naming your form</a>.</p>
-        <p>You can change your name independently of the URL but it's best to ensure your name and URL are closely aligned.</p>
-        <p>You should also ensure that the title of your start page is aligned with the new name.</p>
-        <h3 class="govuk-heading-s">Things to consider when changing the URL</h3>
-        <p>Your form is given a URL when you first create it, based on your form name. All forms sit on the same domain and you are only able to change the first part of the URL (the subdomain). For example, the subdomain in this URL is 'contact-us':</p>
-        <p><u>https://<strong>contact-us</strong>.form.service.justice.gov.uk</u></p>
-        <p>The subdomain selected by MoJ Forms may be shortened and simplified because of URL restrictions. It must:</p>
-        </ul>
-        <li>be a maximum of 57 characters</li>
-        <li>include only lower case letters</li>
-        <li>not include spaces or special characters except hyphens</li>
-        <li>not start with a number</li>
-        </ul>
-        <p>In addition to these restrictions, your URL should be easy to read and closely resemble your form's name and start page title. Words should be separated with hyphens. It's OK to cut small words like articles and conjunctions if you are short of space and the meaning is still clear.</p>
-        <p><a class="govuk-link" href="#top">Back to top</a></p>
-      </section>
-      <section class="content-section content-section--with-top-border">
-      <h2 id="google-analytics" class="govuk-heading-m">Setting up Google Analytics</h2>
-      <p>MoJ Forms allows you to link your form with a Google Analytics account and monitor your form’s performance.</p>
-      <p>You will need:</p>
-      <ul>
-      <li>a Google Analytics account - if you don’t have one already, talk to <a class="govuk-link" href="https://justiceuk.sharepoint.com/sites/DemandandBusinessRelationshipManagement/SitePages/Business-Relationship-Management.aspx">Technology Services Business Relationship Management</a> about raising a service request</li>
-      <li>your analytics tracking ID - see ‘Configuring Google Analytics’</li>
-      </ul>
-      <p>You can enable analytics on your Test and Live sites independently and add different tracking IDs. This allows you to test your analytics first and prevent test activity from being recorded in your live data.</p>
-      <p>To comply with data protection regulations, users are given the option of accepting or rejecting analytics cookies when they first visit your site. This means you will only receive data for the users that actively opt-in to analytics.</p>
-      <h3 class="govuk-heading-s">Configuring Google Analytics</h3>
-      <p>Go to: Settings > Google Analytics</p>
-      <p>On this page, you can enable Google Analytics on the Test site and on the Live site. You need to enable and configure the settings for both sites separately.</p>
-      <p>To enable Google Analytics on a site, check the 'Enable analytics' box. The ‘configure’ settings will then expand to show space for 3 types of tracking IDs. The tracking ID is what links your form to your Google Analytics account. You must enter at least 1 tracking ID and can potentially enter all 3.</p>
-      <p>MoJ Forms supports 3 types of tracking ID:</p>
-      <ul>
-      <li>Universal Analytics Tracking ID - for Google’s legacy analytics service which will be retired in July 2023. This starts with UA, for example: UA-000000-2.</li>
-      <li>Google Analytics 4 Measurement ID - for Google’s latest analytics service, which we recommend for all new forms. This starts with G, for example: G-0000004.</li>
-      <li>Google Tag Manager Container ID - for Google Tag Manager, which is an alternative way of adding analytics code to a form. This starts with GTM, for example: GTM-000003.</li>
-      </ul>
-      <p><a class="govuk-link" href="https://support.google.com/analytics/answer/9539598">How to find your Universal Analytics or Google Analytics 4 ID</a></p>
-      <p><a class="govuk-link" href="https://support.google.com/tagmanager/answer/6103696?hl=en">How to find your Google Tag Manager ID</a></p>
-      <p>You will need to publish your form for the changes to take effect.</p>
-      <h3 class="govuk-heading-s">About cookies</h3>
-      <p>To comply with data protection regulations, all our forms include a default cookies statement in the footer section, along with accessibility and privacy.</p>
-      <p>If you are using either Universal Analytics or Google Analytics 4, this should be sufficient to cover their use of cookies and will not require any additional work.</p>
-      <p>The cookies page is temporarily uneditable while we make some changes to how our footer pages work. If you plan to use Google Tag Manager for any marketing or analytics tools other than Universal Analytics or Google Analytics 4, <a class="govuk-link" href="/contact/">contact us to discuss it</a>.</p>
-      <p><a class="govuk-link" href="#top">Back to top</a></p>
-    </section>
-    <section class="content-section content-section--with-top-border">
-    <h2 id="save-for-later" class="govuk-heading-m">Enabling users to save their progress on a form</h2>
-    <p>If you think users might not be able to complete your form in one sitting, you can enable 'save for later'. This feature lets users save their progress on a form and return to complete it another time.</p>
-    <p>Save for later is a good option for forms that:</p>
-    <ul>
+<section class="content-section content-section--with-top-border">
+  <h2 id="change-name" class="govuk-heading-m">Changing your form's name and URL</h2>
+  <p>You can review and update both your form's name and URL in settings. Go to: Settings > Form name and URL</p>
+  <p>You can change your form's name at any time but you can only change the URL up until you have published your form to Live. After this point, the option is no longer available in settings. This is because changing a Live form's URL can cause problems for users if they have bookmarked the old form or are using an old link. If you need to change a Live form's URL, <a class="govuk-link" href="/contact">contact us to discuss it</a>.</p>
+  <p>You will need to publish your form for any changes to take effect. If you change the URL of a form that has already been published to Test, any links to the old URL will stop working after you publish the new URL.</p>
+  <h3 class="govuk-heading-s">Things to consider when changing the name</h3>
+  <p>The new name should continue to follow the guidelines for <a class="govuk-link" href="/building-and-editing/#form-name">naming your form</a>.</p>
+  <p>You can change your name independently of the URL but it's best to ensure your name and URL are closely aligned.</p>
+  <p>You should also ensure that the title of your start page is aligned with the new name.</p>
+  <h3 class="govuk-heading-s">Things to consider when changing the URL</h3>
+  <p>Your form is given a URL when you first create it, based on your form name. All forms sit on the same domain and you are only able to change the first part of the URL (the subdomain). For example, the subdomain in this URL is 'contact-us':</p>
+  <p><u>https://<strong>contact-us</strong>.form.service.justice.gov.uk</u></p>
+  <p>The subdomain selected by MoJ Forms may be shortened and simplified because of URL restrictions. It must:</p>
+  <ul>
+    <li>be a maximum of 57 characters</li>
+    <li>include only lower case letters</li>
+    <li>not include spaces or special characters except hyphens</li>
+    <li>not start with a number</li>
+  </ul>
+  <p>In addition to these restrictions, your URL should be easy to read and closely resemble your form's name and start page title. Words should be separated with hyphens. It's OK to cut small words like articles and conjunctions if you are short of space and the meaning is still clear.</p>
+  <p><a class="govuk-link" href="#top">Back to top</a></p>
+</section>
+<section class="content-section content-section--with-top-border">
+  <h2 id="google-analytics" class="govuk-heading-m">Setting up Google Analytics</h2>
+  <p>MoJ Forms allows you to link your form with a Google Analytics account and monitor your form’s performance.</p>
+  <p>You will need:</p>
+  <ul>
+    <li>a Google Analytics account - if you don’t have one already, talk to <a class="govuk-link" href="https://justiceuk.sharepoint.com/sites/DemandandBusinessRelationshipManagement/SitePages/Business-Relationship-Management.aspx">Technology Services Business Relationship Management</a> about raising a service request</li>
+    <li>your analytics tracking ID - see ‘Configuring Google Analytics’</li>
+  </ul>
+  <p>You can enable analytics on your Test and Live sites independently and add different tracking IDs. This allows you to test your analytics first and prevent test activity from being recorded in your live data.</p>
+  <p>To comply with data protection regulations, users are given the option of accepting or rejecting analytics cookies when they first visit your site. This means you will only receive data for the users that actively opt-in to analytics.</p>
+  <h3 class="govuk-heading-s">Configuring Google Analytics</h3>
+  <p>Go to: Settings > Google Analytics</p>
+  <p>On this page, you can enable Google Analytics on the Test site and on the Live site. You need to enable and configure the settings for both sites separately.</p>
+  <p>To enable Google Analytics on a site, check the 'Enable analytics' box. The ‘configure’ settings will then expand to show space for 3 types of tracking IDs. The tracking ID is what links your form to your Google Analytics account. You must enter at least 1 tracking ID and can potentially enter all 3.</p>
+  <p>MoJ Forms supports 3 types of tracking ID:</p>
+  <ul>
+    <li>Universal Analytics Tracking ID - for Google’s legacy analytics service which will be retired in July 2023. This starts with UA, for example: UA-000000-2.</li>
+    <li>Google Analytics 4 Measurement ID - for Google’s latest analytics service, which we recommend for all new forms. This starts with G, for example: G-0000004.</li>
+    <li>Google Tag Manager Container ID - for Google Tag Manager, which is an alternative way of adding analytics code to a form. This starts with GTM, for example: GTM-000003.</li>
+  </ul>
+  <p><a class="govuk-link" href="https://support.google.com/analytics/answer/9539598">How to find your Universal Analytics or Google Analytics 4 ID</a></p>
+  <p><a class="govuk-link" href="https://support.google.com/tagmanager/answer/6103696?hl=en">How to find your Google Tag Manager ID</a></p>
+  <p>You will need to publish your form for the changes to take effect.</p>
+  <h3 class="govuk-heading-s">About cookies</h3>
+  <p>To comply with data protection regulations, all our forms include a default cookies statement in the footer section, along with accessibility and privacy.</p>
+  <p>If you are using either Universal Analytics or Google Analytics 4, this should be sufficient to cover their use of cookies and will not require any additional work.</p>
+  <p>The cookies page is temporarily uneditable while we make some changes to how our footer pages work. If you plan to use Google Tag Manager for any marketing or analytics tools other than Universal Analytics or Google Analytics 4, <a class="govuk-link" href="/contact/">contact us to discuss it</a>.</p>
+  <p><a class="govuk-link" href="#top">Back to top</a></p>
+</section>
+<section class="content-section content-section--with-top-border">
+  <h2 id="save-for-later" class="govuk-heading-m">Enabling users to save their progress on a form</h2>
+  <p>If you think users might not be able to complete your form in one sitting, you can enable 'save for later'. This feature lets users save their progress on a form and return to complete it another time.</p>
+  <p>Save for later is a good option for forms that:</p>
+  <ul>
     <li>are long or complex</li>
     <li>include questions that users might want time to think about</li>
     <li>ask for information that users might not have immediately to hand</li>
-    </ul>
-    <p>How it works:
-    <ul>You switch on save for later in your form's settings and publish your form for the change to take effect.</li>
+  </ul>
+  <p>How it works:
+  <ul>You switch on save for later in your form's settings and publish your form for the change to take effect.</li>
     <li>This adds a secondary save button to the bottom of every question page of your form.</li>
     <li>When a user saves their progress, they are asked to enter an email address and a security answer.</li>
     <li>We then email the user a one-off link that they can use to come back to the form and continue.</li>
     <li>The user needs to enter the security answer to retrieve their saved answers. They have 3 attempts to get it right.</li>
     <li>The link is valid for 28 days and will work only once. There is no recovery option if the user loses the link or forgets their security answer.</li>
     <li>Users can save their progress on a form as many times as they like by generating a new link each time.</li>
-    </ul>
-    <p>All user data is encrypted, stored securely and deleted after 28 days.</p>
-    <img src="/images/save-for-later.png" width="100%" alt="Two screenshots are shown alongside each other to illustrate how users can save their progress on a form. The first screenshot is a question page titled Why are you getting in touch? Beneath the question there are 2 buttons - one labelled Continue and another labelled Save for later. A blue arrow suggests that a user would go from this page to the next screenshot which is a page titled Save for later. This page asks the user to enter their email address and set a security answer in order to continue with saving.">
-    <p>To enable save and return, go to: Settings > Save for later</p>
-    <p>Check 'Enable save for later', save and publish your form for the setting to take effect.</p>
-    <p><a class="govuk-link" href="#top">Back to top</a></p>
-  </section>
-      <section class="content-section content-section--with-top-border">
-        <h2 id="email-settings" class="govuk-heading-m">Collecting information by email</h2>
-        <p>When a user completes your form, you can have their form submission emailed to you.</p>
-        <p>The email address you use must be an approved MoJ address. This is to help protect user data and ensure it isn't unknowingly sent outside of the organisation.</p>
-        <p>The answers will be shown in the body of the email and attached to the emails in PDF. They can also be  attached in comma separated values (CSV) format. CSV files list the answers in plain text, separated by commas. They can be imported into spreadsheets and other applications, making it easier to handle and process the information you receive. For example, you could <a class="govuk-link" href="https://support.microsoft.com/en-us/office/import-data-from-a-folder-with-multiple-files-power-query-94b8023c-2e66-4f6b-8c78-6a00041c90e4">import data from multiple CSV files into Microsoft Excel</a> at once.</p>
-        <p>All data received from a form is labelled OFFICIAL-SENSITIVE. This is to comply with the Government Security Classifications Policy. (Find out more about <a class="govuk-link" href="/getting-started/#security-classifications">security classifications for your form</a>.)
-        <p>Currently, email is the only way to collect the information your users submit. We plan to introduce other options, such as API integration, at a later time.</p>
-        <h3 class="govuk-heading-s">Setting up the emails</h3>
-        <p>Go to: Settings > Submission settings > Collect information by email</p>
-        <p>On this page, you can enable collecting information by email on the Test site and on the Live site. You need to enable and configure the settings for both sites separately. The answers are attached in a PDF and can be additionally attached in a CSV.</p>
-        <p>To enable the setting on a site, check the 'Enable email' box. The 'configure' settings will then expand and allow you to enter the email address you want the emails sent to. This address should be:</p>
-        <ul>
-        <li>an MoJ email address, such as @justice.gov.uk or @digital.justice.gov.uk, or other approved address - if the address you want to use isn't accepted, <a class="govuk-link" href="/contact">contact us</a> to discuss your requirements</li>
-        <li>a team email account with several authorised users to ensure you can maintain your service in the event of team changes or absences</li>
-        </ul>
-        <p>Currently you can send the form to only one address.</p>
-        <p>There are a number of other email configuration options:</p>
-        <ul>
-        <li>Subject - the subject line of the email</li>
-        <li>Message - the body text of the email</li>
-        <li>PDF heading - in the attachment containing user answers (<a class="govuk-link" href="https://moj-forms-editor.service.justice.gov.uk/sample.pdf">see a sample PDF</a>)</li>
-        <li>PDF subheading - in the attachment containing user answers (<a class="govuk-link" href="https://moj-forms-editor.service.justice.gov.uk/sample.pdf">see a sample PDF</a>)</li>
-        <li>CSV attachment - opt to receive an additional email with user answers in CSV format (<a class="govuk-link" href="https://moj-forms-editor.service.justice.gov.uk/sample.csv">see a sample CSV</a>)</li>
-        </ul>
-        <p><a class="govuk-link" href="#top">Back to top</a></p>
-      </section>
-      <section class="content-section content-section--with-top-border">
-      <h2 id="confirmation-email" class="govuk-heading-m">Sending users a confirmation email</h2>
-      <p>You can configure your form to send users a confirmation email when they submit their answers. The message can be customised to your service and the user's answers will be inserted into the email.</p>
-      <p>A confirmation email can be used to:</p>
-      <ul>
-      <li>reassure users that their information was submitted successfully</li>
-      <li>allow users to double-check the information they provided and keep it for reference</li>
-      <li>help you repeat and reinforce important messages from the confirmation page, such as response times and contact details</li>
-      </ul>
-      <p>The email will be sent by a generic MoJ Forms email address but show as coming from your form name.</p>
-      <img src="/images/confirmation-email-inbox.png" alt="A screenshot of an email inbox. A red arrow points to the top email which is from Find out if MoJ For. (The full name appears to have been truncated.) The subject of the email is Your submission to Find out if MoJ Forms is right for you." class="screenshot-image">
-      <p>You will need to set an email address for users to reply to - even if you don't want users to reply. Users may reply anyway and could include personal information. For data protection purposes, these emails should only go to your team.</p>
-      <p>The reply address should be:</p>
-      <ul>
-      <li>a username that is easily associated with your form</li>
-      <li>an MoJ email address, such as @justice.gov.uk or @digital.justice.gov.uk, or other approved address - if the address you want to use isn't accepted, <a class="govuk-link" href="/contact">contact us</a> to discuss your requirements</li>
-      <li>a team email account with several authorised users to ensure you can maintain your service in the event of team changes or absences</li>
-      </ul>
-      <p>To deter replies, you could:</p>
-      <ul>
-      <li>include appropriate contact details in the confirmation email</li>
-      <li>create a separate email address for replies and set an auto-reply message with meaningful information</li>
-      </ul>
-      <h3 class="govuk-heading-s">Setting up the confirmation email</h3>
-      <p>To enable this feature, you will need to capture your users' email addresses using an <a class="govuk-link" href="/building-and-editing/#question-formats">email address question</a>. You will need at least one question of this type before you can set up the confirmation email.</p>
-      <p>Once you have an email address question in your form, go to: Settings > Submission settings > Send a confirmation email</p>
-      <p>On this page, you can enable a confirmation email on the Test site and on the Live site. You need to enable and configure the settings for both sites separately.</p>
-      <p>To enable it on a site, check the 'Enable confirmation email' box. The 'configure' panel will then expand to show the following settings:<p>
-      <ul> 
-      <li>Reply to - the email address that replies will go to</li>
-      <li>To the email address captured by - the question in your form that asks the user for their email address (if there is more than one email address question in your form, you will be able to select between them)</li>
-      <li>Subject - the subject line of the email</li>
-      <li>Message - the body text of the email</li>
-      </ul>
-      <p>The user's answers will be inserted into the email beneath the message. (You won't see this in the settings page.) The message does not currently support any rich text formatting such as headings or bullet points.</p>
-      <p>When you enable confirmation email, MoJ Forms automatically adds disclaimers to your form to let users know how their email address will be used. These disclaimers appear:</p>
-      <ul>
-      <li>directly beneath the question used to capture the user's email address</li>
-      <li>on the check answers page, before the submit button</li>
-      </ul>
-      <img src="/images/confirmation-email-disclaimers.jpg" width="100%" alt="Two screenshots show the places where disclaimers are added automatically to forms that send confirmation emails. In one, a question page is titled Do you want to receive a confirmation email? with a disclaimer that reads We will use this address to send you a confirmation email with a copy of your answers. The second screenshot shows the check answers page with a disclaimer and submit button.">
-      <p>These messages are not currently editable. If you plan on using the email address for other purposes, you should mention this in the question's hint text.</p>
-      <p><a class="govuk-link" href="#top">Back to top</a></p>
-    </section>
-    <section class="content-section content-section--with-top-border">
-      <h2 id="references" class="govuk-heading-m">Providing users with reference numbers</h2>
-      <p>MoJ Forms can generate unique reference numbers for each submission made by your form. This can make it easier to keep track of the submissions you receive and discuss them with users should the need arise.</p>
-      <img src="/images/confirmation-page-with-reference-number.png" alt="A screenshot shows the confirmation page of a form titled: Contact us about a case. The screen is dominated by a large green box which contains the message: Thank you for contacting us about a case. Your reference number is: M35-CL64-Z5Y." class="screenshot-image">
-      <p>For each submission, a unique reference number is generated and inserted into:</p>
-      <ul>
-      <li>the confirmation page</li>
-      <li>the subject and message of the <a class="govuk-link" href="/settings/#email-settings">submission email</a></li>
-      <li>the PDF and CSV attachments of user answers</li>
-      <li>the subject and message of the <a class="govuk-link" href="/settings/#confirmation-email">confirmation email</a></li>
-      </ul>
-      <p>(You will need to enable the emails separately.)</p>
-      <p>MoJ Forms reference numbers are a mixture of 10 letters and numbers such as A12&#8209;B345&#8209;C67.</p>
-      <h3 class="govuk-heading-s">Setting up reference numbers</h3>
-      <p>Go to the settings page (Settings > Reference numbers and GOV.UK Pay) and check "Enable reference numbers".</p>
-      <p>This will insert a placeholder for the reference number into your confirmation page, submission email and confirmation email templates (for both Test and Live sites).</p>
-      <img src="/images/reference-number-email-template.png" alt="A screenshot from the MoJ Forms editor shows the settings page for a confirmation email. The subject and message both include placeholder text indicating where the reference number will be inserted." class="screenshot-image">
-      <p>You can edit the email content and use the placeholder {{reference_number}} wherever you want the reference number to appear.</p>
-      <p>When you enable or disable reference numbers it will overwrite any custom text in your email templates and reset them to default text. You may therefore want to take a copy of your emails before changing this setting.</p> 
-      <p><a class="govuk-link" href="#top">Back to top</a></p>
-    </section>
-    <section class="content-section content-section--with-top-border">
-      <h2 id="payment-links" class="govuk-heading-m">Taking payments through GOV.UK Pay</h2>
-      <p>If you have a GOV.UK Pay account and are set up to take payments through a payment link, MoJ Forms can help you join up form submissions with payments.</p>
-      <img src="/images/confirmation-page-to-gov-pay.png" width="100%" alt="Two screenshots are shown alongside each other to illustrate how MoJ Forms can join up with GOV.UK Pay. The first screenshot is the confirmation page of a form titled Apply for a licence. A large blue box includes the words 'you still need to pay' and a reference number. Beneath the box is a button labelled continue to pay. A blue arrow suggests that a user would go from this page to the next screenshot which is a GOV.UK payment page. It is titled Pay for a licence application and includes the same reference number shown on the first screenshot.">
-      <p>How it works:</p>
-      <ul>
-      <li>In GOV.UK Pay, you <a class="govuk-link" href="https://www.payments.service.gov.uk/govuk-payment-pages/">create a payment link</a>.</li>
-      <li>In your form, you enable GOV.UK Pay payment links and reference numbers and enter your payment link URL. </li>
-      <li>MoJ Forms then combines your payment link with the reference number and inserts the new link into the confirmation page and confirmation email. (You will need to enable the <a class="govuk-link" href="/settings/#confirmation-email">confirmation email settings</a> separately.)</li>
-      <li>After a user completes your form, they use the payment link to visit GOV.UK Pay to make a payment. This automatically applies the MoJ Forms reference number to the payment.</li>
-      <li>You can then use the reference number to match a payment with the corresponding form submission.</li>
-      </ul>
-      <h3 class="govuk-heading-s">Setting up GOV.UK Pay</h3>
-      <p>Before you can take payments in this way you will need to:</p>
-      <ul>
-      <li>set up a <a class="govuk-link" href="https://www.payments.service.gov.uk/">GOV.UK Pay account</a></li>
-      <li>talk to your local finance team to set up a payment service provider</li>
-      </ul>
-      <p>You can create a GOV.UK Pay account and set up a test payment link in just a few minutes but it may be several months before you are ready to take payments. This depends on the payment service provider arrangements in your area. For example, MoJ, HMCTS and HMPPS all have separate agreements with the Government Banking Service.</p>
-      <h3 class="govuk-heading-s">Setting up GOV.UK Pay payment links</h3>
-      <p>Go to the settings page (Settings > Reference numbers and GOV.UK Pay) and check both settings:</p>
-      <ul>
-      <li>Enable reference numbers</li>
-      <li>Add payment links with reference numbers</li>
-      </ul>
-      <p>Then enter your GOV.UK Pay payment link URL into the field provided. You get this from your GOV.UK Pay account and it should start with "https://gov.uk". When setting this up, ensure you select 'yes' when asked if your users already have a payment reference. This is the field that will be pre-filled for your users with the MoJ Forms reference number.</p>
-      <p>This will then insert placeholders for the payment link into your confirmation page and confirmation email templates (for both Test and Live sites). It will also insert separate placeholders for the reference number in several places. (See <a class="govuk-link" href="#references">Providing users with reference numbers</a>.)</p>
-      <img src="/images/payment-link-email-template.png" alt="A screenshot from the MoJ Forms editor shows the settings page for a confirmation email. The message includes placeholder text indicating where the payment link will be inserted." class="screenshot-image">
-      <p>You can edit the email content and use the placeholder {{payment_link}} wherever you want the payment link to appear.</p>
-      <p>When you enable or disable payment links it will overwrite any custom text in your email templates and reset them to default text. You may therefore want to take a copy of your emails before changing this setting.</p>
-      <p><a class="govuk-link" href="#top">Back to top</a></p>
-    </section>
-    <section class="content-section content-section--with-top-border">
-      <h2 id="transfer-form" class="govuk-heading-m">Transferring your form to another user</h2>
-      <p>You can transfer your form to another MoJ Forms user by changing your form's 'owner' in settings.</p>
-      <p>A form can have only one owner at a time. Only the owner can see the form on the 'Your forms' page and open the form in the MoJ Forms editor.</p>
-      <h3 class="govuk-heading-s">Transferring a form</h3>
-      <p>Go to: Settings > Change form owner</p>
-      <p>Enter the email address of the person you want to transfer the form to. They must already be an MoJ Forms user and have signed into MoJ Forms at least once.</p>
-      <p>If they aren't a user yet, ask them to <a class="govuk-link" href="/contact/">contact us</a> to get access.</p>
-      <p>Once you change the form's owner, you will be taken back to 'Your forms' and no longer see or be able to access the form.</p>
-      <p>The new form owner will be notified by email of the change.</p>
-      <p><a class="govuk-link" href="#top">Back to top</a></p>
-    </section>
-        <!-- END CONTENT -->
-      </div>
-    </div>
-  </main>
-</div>
+  </ul>
+  <p>All user data is encrypted, stored securely and deleted after 28 days.</p>
+  <img src="/images/save-for-later.png" width="100%" alt="Two screenshots are shown alongside each other to illustrate how users can save their progress on a form. The first screenshot is a question page titled Why are you getting in touch? Beneath the question there are 2 buttons - one labelled Continue and another labelled Save for later. A blue arrow suggests that a user would go from this page to the next screenshot which is a page titled Save for later. This page asks the user to enter their email address and set a security answer in order to continue with saving.">
+  <p>To enable save and return, go to: Settings > Save for later</p>
+  <p>Check 'Enable save for later', save and publish your form for the setting to take effect.</p>
+  <p><a class="govuk-link" href="#top">Back to top</a></p>
+</section>
+<section class="content-section content-section--with-top-border">
+  <h2 id="email-settings" class="govuk-heading-m">Collecting information by email</h2>
+  <p>When a user completes your form, you can have their form submission emailed to you.</p>
+  <p>The email address you use must be an approved MoJ address. This is to help protect user data and ensure it isn't unknowingly sent outside of the organisation.</p>
+  <p>The answers will be shown in the body of the email and attached to the emails in PDF. They can also be  attached in comma separated values (CSV) format. CSV files list the answers in plain text, separated by commas. They can be imported into spreadsheets and other applications, making it easier to handle and process the information you receive. For example, you could <a class="govuk-link" href="https://support.microsoft.com/en-us/office/import-data-from-a-folder-with-multiple-files-power-query-94b8023c-2e66-4f6b-8c78-6a00041c90e4">import data from multiple CSV files into Microsoft Excel</a> at once.</p>
+  <p>All data received from a form is labelled OFFICIAL-SENSITIVE. This is to comply with the Government Security Classifications Policy. (Find out more about <a class="govuk-link" href="/getting-started/#security-classifications">security classifications for your form</a>.)
+  <p>Currently, email is the only way to collect the information your users submit. We plan to introduce other options, such as API integration, at a later time.</p>
+  <h3 class="govuk-heading-s">Setting up the emails</h3>
+  <p>Go to: Settings > Submission settings > Collect information by email</p>
+  <p>On this page, you can enable collecting information by email on the Test site and on the Live site. You need to enable and configure the settings for both sites separately. The answers are attached in a PDF and can be additionally attached in a CSV.</p>
+  <p>To enable the setting on a site, check the 'Enable email' box. The 'configure' settings will then expand and allow you to enter the email address you want the emails sent to. This address should be:</p>
+  <ul>
+    <li>an MoJ email address, such as @justice.gov.uk or @digital.justice.gov.uk, or other approved address - if the address you want to use isn't accepted, <a class="govuk-link" href="/contact">contact us</a> to discuss your requirements</li>
+    <li>a team email account with several authorised users to ensure you can maintain your service in the event of team changes or absences</li>
+  </ul>
+  <p>Currently you can send the form to only one address.</p>
+  <p>There are a number of other email configuration options:</p>
+  <ul>
+    <li>Subject - the subject line of the email</li>
+    <li>Message - the body text of the email</li>
+    <li>PDF heading - in the attachment containing user answers (<a class="govuk-link" href="https://moj-forms-editor.service.justice.gov.uk/sample.pdf">see a sample PDF</a>)</li>
+    <li>PDF subheading - in the attachment containing user answers (<a class="govuk-link" href="https://moj-forms-editor.service.justice.gov.uk/sample.pdf">see a sample PDF</a>)</li>
+    <li>CSV attachment - opt to receive an additional email with user answers in CSV format (<a class="govuk-link" href="https://moj-forms-editor.service.justice.gov.uk/sample.csv">see a sample CSV</a>)</li>
+  </ul>
+  <p><a class="govuk-link" href="#top">Back to top</a></p>
+</section>
+<section class="content-section content-section--with-top-border">
+  <h2 id="confirmation-email" class="govuk-heading-m">Sending users a confirmation email</h2>
+  <p>You can configure your form to send users a confirmation email when they submit their answers. The message can be customised to your service and the user's answers will be inserted into the email.</p>
+  <p>A confirmation email can be used to:</p>
+  <ul>
+    <li>reassure users that their information was submitted successfully</li>
+    <li>allow users to double-check the information they provided and keep it for reference</li>
+    <li>help you repeat and reinforce important messages from the confirmation page, such as response times and contact details</li>
+  </ul>
+  <p>The email will be sent by a generic MoJ Forms email address but show as coming from your form name.</p>
+  <img src="/images/confirmation-email-inbox.png" alt="A screenshot of an email inbox. A red arrow points to the top email which is from Find out if MoJ For. (The full name appears to have been truncated.) The subject of the email is Your submission to Find out if MoJ Forms is right for you." class="screenshot-image">
+  <p>You will need to set an email address for users to reply to - even if you don't want users to reply. Users may reply anyway and could include personal information. For data protection purposes, these emails should only go to your team.</p>
+  <p>The reply address should be:</p>
+  <ul>
+    <li>a username that is easily associated with your form</li>
+    <li>an MoJ email address, such as @justice.gov.uk or @digital.justice.gov.uk, or other approved address - if the address you want to use isn't accepted, <a class="govuk-link" href="/contact">contact us</a> to discuss your requirements</li>
+    <li>a team email account with several authorised users to ensure you can maintain your service in the event of team changes or absences</li>
+  </ul>
+  <p>To deter replies, you could:</p>
+  <ul>
+    <li>include appropriate contact details in the confirmation email</li>
+    <li>create a separate email address for replies and set an auto-reply message with meaningful information</li>
+  </ul>
+  <h3 class="govuk-heading-s">Setting up the confirmation email</h3>
+  <p>To enable this feature, you will need to capture your users' email addresses using an <a class="govuk-link" href="/building-and-editing/#question-formats">email address question</a>. You will need at least one question of this type before you can set up the confirmation email.</p>
+  <p>Once you have an email address question in your form, go to: Settings > Submission settings > Send a confirmation email</p>
+  <p>On this page, you can enable a confirmation email on the Test site and on the Live site. You need to enable and configure the settings for both sites separately.</p>
+  <p>To enable it on a site, check the 'Enable confirmation email' box. The 'configure' panel will then expand to show the following settings:<p>
+  <ul> 
+    <li>Reply to - the email address that replies will go to</li>
+    <li>To the email address captured by - the question in your form that asks the user for their email address (if there is more than one email address question in your form, you will be able to select between them)</li>
+    <li>Subject - the subject line of the email</li>
+    <li>Message - the body text of the email</li>
+  </ul>
+  <p>The user's answers will be inserted into the email beneath the message. (You won't see this in the settings page.) The message does not currently support any rich text formatting such as headings or bullet points.</p>
+  <p>When you enable confirmation email, MoJ Forms automatically adds disclaimers to your form to let users know how their email address will be used. These disclaimers appear:</p>
+  <ul>
+    <li>directly beneath the question used to capture the user's email address</li>
+    <li>on the check answers page, before the submit button</li>
+  </ul>
+  <img src="/images/confirmation-email-disclaimers.jpg" width="100%" alt="Two screenshots show the places where disclaimers are added automatically to forms that send confirmation emails. In one, a question page is titled Do you want to receive a confirmation email? with a disclaimer that reads We will use this address to send you a confirmation email with a copy of your answers. The second screenshot shows the check answers page with a disclaimer and submit button.">
+  <p>These messages are not currently editable. If you plan on using the email address for other purposes, you should mention this in the question's hint text.</p>
+  <p><a class="govuk-link" href="#top">Back to top</a></p>
+</section>
+<section class="content-section content-section--with-top-border">
+  <h2 id="references" class="govuk-heading-m">Providing users with reference numbers</h2>
+  <p>MoJ Forms can generate unique reference numbers for each submission made by your form. This can make it easier to keep track of the submissions you receive and discuss them with users should the need arise.</p>
+  <img src="/images/confirmation-page-with-reference-number.png" alt="A screenshot shows the confirmation page of a form titled: Contact us about a case. The screen is dominated by a large green box which contains the message: Thank you for contacting us about a case. Your reference number is: M35-CL64-Z5Y." class="screenshot-image">
+  <p>For each submission, a unique reference number is generated and inserted into:</p>
+  <ul>
+    <li>the confirmation page</li>
+    <li>the subject and message of the <a class="govuk-link" href="/settings/#email-settings">submission email</a></li>
+    <li>the PDF and CSV attachments of user answers</li>
+    <li>the subject and message of the <a class="govuk-link" href="/settings/#confirmation-email">confirmation email</a></li>
+  </ul>
+  <p>(You will need to enable the emails separately.)</p>
+  <p>MoJ Forms reference numbers are a mixture of 10 letters and numbers such as A12&#8209;B345&#8209;C67.</p>
+  <h3 class="govuk-heading-s">Setting up reference numbers</h3>
+  <p>Go to the settings page (Settings > Reference numbers and GOV.UK Pay) and check "Enable reference numbers".</p>
+  <p>This will insert a placeholder for the reference number into your confirmation page, submission email and confirmation email templates (for both Test and Live sites).</p>
+  <img src="/images/reference-number-email-template.png" alt="A screenshot from the MoJ Forms editor shows the settings page for a confirmation email. The subject and message both include placeholder text indicating where the reference number will be inserted." class="screenshot-image">
+  <p>You can edit the email content and use the placeholder {{reference_number}} wherever you want the reference number to appear.</p>
+  <p>When you enable or disable reference numbers it will overwrite any custom text in your email templates and reset them to default text. You may therefore want to take a copy of your emails before changing this setting.</p> 
+  <p><a class="govuk-link" href="#top">Back to top</a></p>
+</section>
+<section class="content-section content-section--with-top-border">
+  <h2 id="payment-links" class="govuk-heading-m">Taking payments through GOV.UK Pay</h2>
+  <p>If you have a GOV.UK Pay account and are set up to take payments through a payment link, MoJ Forms can help you join up form submissions with payments.</p>
+  <img src="/images/confirmation-page-to-gov-pay.png" width="100%" alt="Two screenshots are shown alongside each other to illustrate how MoJ Forms can join up with GOV.UK Pay. The first screenshot is the confirmation page of a form titled Apply for a licence. A large blue box includes the words 'you still need to pay' and a reference number. Beneath the box is a button labelled continue to pay. A blue arrow suggests that a user would go from this page to the next screenshot which is a GOV.UK payment page. It is titled Pay for a licence application and includes the same reference number shown on the first screenshot.">
+  <p>How it works:</p>
+  <ul>
+    <li>In GOV.UK Pay, you <a class="govuk-link" href="https://www.payments.service.gov.uk/govuk-payment-pages/">create a payment link</a>.</li>
+    <li>In your form, you enable GOV.UK Pay payment links and reference numbers and enter your payment link URL. </li>
+    <li>MoJ Forms then combines your payment link with the reference number and inserts the new link into the confirmation page and confirmation email. (You will need to enable the <a class="govuk-link" href="/settings/#confirmation-email">confirmation email settings</a> separately.)</li>
+    <li>After a user completes your form, they use the payment link to visit GOV.UK Pay to make a payment. This automatically applies the MoJ Forms reference number to the payment.</li>
+    <li>You can then use the reference number to match a payment with the corresponding form submission.</li>
+  </ul>
+  <h3 class="govuk-heading-s">Setting up GOV.UK Pay</h3>
+  <p>Before you can take payments in this way you will need to:</p>
+  <ul>
+    <li>set up a <a class="govuk-link" href="https://www.payments.service.gov.uk/">GOV.UK Pay account</a></li>
+    <li>talk to your local finance team to set up a payment service provider</li>
+  </ul>
+  <p>You can create a GOV.UK Pay account and set up a test payment link in just a few minutes but it may be several months before you are ready to take payments. This depends on the payment service provider arrangements in your area. For example, MoJ, HMCTS and HMPPS all have separate agreements with the Government Banking Service.</p>
+  <h3 class="govuk-heading-s">Setting up GOV.UK Pay payment links</h3>
+  <p>Go to the settings page (Settings > Reference numbers and GOV.UK Pay) and check both settings:</p>
+  <ul>
+    <li>Enable reference numbers</li>
+    <li>Add payment links with reference numbers</li>
+  </ul>
+  <p>Then enter your GOV.UK Pay payment link URL into the field provided. You get this from your GOV.UK Pay account and it should start with "https://gov.uk". When setting this up, ensure you select 'yes' when asked if your users already have a payment reference. This is the field that will be pre-filled for your users with the MoJ Forms reference number.</p>
+  <p>This will then insert placeholders for the payment link into your confirmation page and confirmation email templates (for both Test and Live sites). It will also insert separate placeholders for the reference number in several places. (See <a class="govuk-link" href="#references">Providing users with reference numbers</a>.)</p>
+  <img src="/images/payment-link-email-template.png" alt="A screenshot from the MoJ Forms editor shows the settings page for a confirmation email. The message includes placeholder text indicating where the payment link will be inserted." class="screenshot-image">
+  <p>You can edit the email content and use the placeholder {{payment_link}} wherever you want the payment link to appear.</p>
+  <p>When you enable or disable payment links it will overwrite any custom text in your email templates and reset them to default text. You may therefore want to take a copy of your emails before changing this setting.</p>
+  <p><a class="govuk-link" href="#top">Back to top</a></p>
+</section>
+<section class="content-section content-section--with-top-border">
+  <h2 id="transfer-form" class="govuk-heading-m">Transferring your form to another user</h2>
+  <p>You can transfer your form to another MoJ Forms user by changing your form's 'owner' in settings.</p>
+  <p>A form can have only one owner at a time. Only the owner can see the form on the 'Your forms' page and open the form in the MoJ Forms editor.</p>
+  <h3 class="govuk-heading-s">Transferring a form</h3>
+  <p>Go to: Settings > Change form owner</p>
+  <p>Enter the email address of the person you want to transfer the form to. They must already be an MoJ Forms user and have signed into MoJ Forms at least once.</p>
+  <p>If they aren't a user yet, ask them to <a class="govuk-link" href="/contact/">contact us</a> to get access.</p>
+  <p>Once you change the form's owner, you will be taken back to 'Your forms' and no longer see or be able to access the form.</p>
+  <p>The new form owner will be notified by email of the change.</p>
+  <p><a class="govuk-link" href="#top">Back to top</a></p>
+</section>

--- a/source/testing-and-publishing.html.erb
+++ b/source/testing-and-publishing.html.erb
@@ -3,135 +3,123 @@ title: Testing and publishing
 heading: Testing and publishing
 category: user-guide
 order: 8
+layout: user_guide
 ---
-<div class="govuk-width-container">
-  <main class="govuk-main-wrapper govuk-body" id="main-content" role="main">
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-one-quarter">
-        <%= partial "user_nav" %>
-      </div>
-      <div class="govuk-grid-column-three-quarters">
-        <h1 class="govuk-heading-l"><%= current_page.data.heading %></h1>
-        <!-- START CONTENT -->
-        <p class="govuk-body-l">How to test your form and share it securely with colleagues before publishing the final version.</p>
-        <h2 class="govuk-heading-m">Contents</h2>
-        <%= partial "toc", locals: { links: { 
-          'publishing-process': "Understanding the publishing process",
-          'before-publishing': "Things to check before publishing",
-          'test': "Publishing to Test",
-          'test-checks': "What to look for when testing",
-          'final-check': "Unlocking the ability to publish to Live",
-          'live': "Publishing to Live",
-          'live-checks': "What to check on Live",
-          'govuk': "Getting your form on GOV.UK",
-        }} %>
-        <section class="content-section content-section--with-top-border">
-        <h2 id="publishing-process" class="govuk-heading-m">Understanding the publishing process</h2>
-        <p>To see a fully working form that you can fill in and share with others, you have to publish it. MoJ Forms comes with both a Test site and Live site so that you can work on your form and only push changes live when you are happy with them. All changes made in the editor, including to settings, have to be published for them to take effect.<p>
-        <p>The Test site is for checking your form, sharing it with colleagues and stakeholders and gathering feedback. You can make multiple changes and updates to the Test site without needing to publish to Live. All test forms are protected by username and password, which you set when publishing.</p>
-        <p>The Live site is where your final form will live. This version can be shared with users and linked to from GOV.UK. You only need to publish to Live when you are happy with your form on the Test site. Live forms can be protected with a username and password if required.</p>
-        <p>Test forms have the URL: your-form-name.dev.form.service.justice.gov.uk<br>
-        Live forms have the URL: your-form-name.form.service.justice.gov.uk</p>
-        <p>Both the Test and Live sites:</p>
-        <ul>
-        <li>are on the internet, so there are no restrictions on who you can share the links with</li>
-        <li>will not be found and listed on search engines</li>
-        </ul>
-        <p><a class="govuk-link" href="#top">Back to top</a></p>
-      </section>
-      <section class="content-section content-section--with-top-border">
-        <h2 id="before-publishing" class="govuk-heading-m">Things to check before publishing</h2>
-        <p>The publishing page will check your form and warn you about some of the most common issues.</p>
-        <img src="/images/publishing-warnings.png" alt="A screenshot of the publishing page in MoJ Forms showing a publishing warning. A red arrow on the screenshot points to the warning which is above a blue button reading Publish to Test. The warning reads Which MoJ agency or body do you work for? has no autocomplete options and cannot be answered." class="screenshot-image">
-        <p>These checks include:</p> 
-        <ul>
-        <li>Whether you have enabled <a class="govuk-link" href="/settings/#email-settings">collecting information by email</a>. This is required if you want to receive any submissions from your form. It is also required if you want your form to send confirmation emails.</li>
-        <li>Whether your form contains a <a class="govuk-link" href="/building-and-editing/#check-confirm">check answers page and a confirmation page</a>. These are required if you want to receive any submissions from your form.</li>
-        <li>Whether you form includes any <a class="govuk-link" href="/building-and-editing/#autocomplete">autocomplete questions</a> without options. This means users will be unable to complete the question and could prevent them from completing your form.</li>
-        </ul>
-        <p>You will be able to publish your form to Test even with these issues but some features won't work.</p>
-        <p>However, you will not be able to publish a form to Live that contains an autocomplete question without any options. The button will be inactive (grey and unclickable) until this issue has been resolved.</p>
-        <p><a class="govuk-link" href="#top">Back to top</a></p>
-      </section>
-      <section class="content-section content-section--with-top-border">
-        <h2 id="test" class="govuk-heading-m">Publishing to Test</h2>
-        <p>To publish your form to the Test site, go to the publishing page and select 'publish to Test'. This will publish the version of your form in the editor to the Test site.</p>
-        <p>You will be asked to set a username and password for your form which will be required to view the form. All forms on the Test site are protected in this way. You will need to share these credentials with anyone you want to view the form.</p>
-        <p>If you forget what username and password you set, you can simply re-publish your form and set new details. These will replace your previous username and password.</p>
-        <p>It can take up to 15 minutes for the form to be visible the first time you publish it to Test. Updates are much quicker and should publish within a minute or less. (You may need to refresh your browser or clear your cache.)</p>
-        <img src="/images/publish-to-test.png" alt="The URL of a form is displayed on the publishing page after the form has been published." class="screenshot-image">
-        <p><a class="govuk-link" href="#top">Back to top</a></p>
-      </section>
-      <section class="content-section content-section--with-top-border">
-        <h2 id="test-checks" class="govuk-heading-m">What to look for when testing</h2>
-        <p>We recommend you always publish and test your form on the Test site before publishing to Live. Some of the things to look for are:</p>
-        <ul>
-        <li>any markdown you have used to format content is displaying correctly and any links are working as expected</li>
-        <li>questions are correctly flagged as optional or required</li>
-        <li>any branching within your form is working as expected</li>
-        <li>your form includes a check answers page and confirmation page if you want it to submit the data it collects</li>
-        <li>you are able to complete and submit a form using the Test URL</li>
-        <li>the submitted form content is going to the right email address</li>
-        <li>confirmation emails are being sent correctly if you have enabled this setting</li>
-        <li>your Google Analytics account is collecting data if you have enabled this setting (this can take up to 48 hours in Google Analytics 4)</li>
-        </ul>
-        <p>This is the time you should also start thinking about:</p> 
-        <ul>
-        <li>completing your <a class="govuk-link" href="/data-protection/#privacynotice">privacy notice template</a></li>
-        <li>conducting a <a class="govuk-link" href="/accessibility">basic accessibility check</a> and completing your <a class="govuk-link" href="/accessibility/#statement">accessibility statement</a></li>
-        </ul>
-        <p><a class="govuk-link" href="#top">Back to top</a></p>
-      </section>
-      <section class="content-section content-section--with-top-border">
-      <h2 id="final-check" class="govuk-heading-m">Unlocking the ability to publish to Live</h2>
-      <p>When you are satisfied that your form is ready, you need to apply to unlock the ability to publish to Live.</p>
-      <p>The MoJ Forms team will review your form against the MoJ Forms terms of use and confirm that:</p>
-      <ul>
-      <li>the form has been designed for legitimate purposes and not for illegal or inappropriate use</li>
-      <li>the privacy statement has been completely in full</li>
-      <li>the accessibility statement has been completed in full</li> 
-      </ul>
-      <p>This can take up to 3 working days.</p>
-      <p>The MoJ Forms team will then either unlock your ability to publish to Live or contact you to discuss any issues.</p>
-      <p>Once publishing to Live has been unlocked, you are free to publish your form at any time. You won't need to go through this process again for any future updates.</p>
-      <h3 class="govuk-heading-s">How to unlock publishing to Live</h3>
-      <p>When you are satisfied that your form is ready, go to the publishing page and select the 'Publish to Live' tab. If your form has not been published to Live yet, you will see a checklist of actions and a button labelled "Apply to unlock publishing".</p>  
-      <img src="/images/publishing-final-check.png" alt="A screenshot shows the MoJ Forms publishing page. The Publish to Live tab is active. A subheading reads Unlock publishing to Live and is followed by a checklist of actions." class="screenshot-image">
-      <p>Review the actions carefully and check each box to confirm that you have completed them before clicking "Apply to unlock publishing".</p>
-      <p>Normally, publishing will be unlocked within 3 working days and you will receive a confirmation by email. If there are any issues, a member of the MoJ Forms team will contact you directly.</p>
-      <p><a class="govuk-link" href="#top">Back to top</a></p>
-    </section>
-      <section class="content-section content-section--with-top-border">
-        <h2 id="live" class="govuk-heading-m">Publishing to Live</h2>
-        <p>To publish your form to the Live site, go to the publishing page and select the 'Publish to Live' tab. If you are publishing your form to Live for the first time, you will need to <a class="govuk-link" href="#final-check">apply to unlock publishing</a> first.</p>
-        <p>Once you have unlocked publishing, you will see a blue 'Publish to Live' button. If it is inactive (grey and unclickable) this means there are issues with your form that you will need to resolve before you can publish. See <a class="govuk-link" href="#before-publishing">things to check before publishing</a> for details.
-        <p>Publishing will promote the latest version of your form in the editor to the Live site.</p>
-        <p>After selecting 'Publish to Live', you will be presented with 2 options:</p>
-        <ul>
-        <li>allow anyone with the link to view</li>
-        <li>set a username and password</li>
-        </ul>
-        <p>If you set a username and password, you will need to share these with anyone you want to view the form. If you forget what username and password you set, you can simply re-publish your form and set new details. These will replace your previous username and password.</p>
-        <p>It can take up to 15 minutes for the form to be visible the first time you publish it to Live. Updates are much quicker and should appear within a minute or less. (You may need to refresh your browser or clear your cache.)</p>
-        <p><a class="govuk-link" href="#top">Back to top</a></p>
-      </section>
-      <section class="content-section content-section--with-top-border">
-        <h2 id="live-checks" class="govuk-heading-m">What to check on Live</h2>
-        <p>Always check your live form is working as expected before sharing with users. Some things to look for are:</p>
-        <ul>
-        <li>you are able to complete and submit a form using the Live URL</li>
-        <li>you are able to access the form without a username and password (unless you intend to keep the form password protected)</li>
-        <li>the submitted form content is going to the right email address</li>
-        </ul>
-        <p><a class="govuk-link" href="#top">Back to top</a></p>
-      </section>
-      <section class="content-section content-section--with-top-border">
-      <h2 id="govuk" class="govuk-heading-m">Getting your form on GOV.UK</h2>
-      <p>If you want to put your form on GOV.UK, you will need to talk to your local comms team. They will help you decide where the form should sit and help you with any guidance content that may be required around it.</p>
-      <p><a class="govuk-link" href="#top">Back to top</a></p>
-    </section>
-        <!-- END CONTENT -->
-      </div>
-    </div>
-  </main>
-</div>
+<h1 class="govuk-heading-l"><%= current_page.data.heading %></h1>
+<p class="govuk-body-l">How to test your form and share it securely with colleagues before publishing the final version.</p>
+<h2 class="govuk-heading-m">Contents</h2>
+<%= partial "toc", locals: { links: { 
+  'publishing-process': "Understanding the publishing process",
+  'before-publishing': "Things to check before publishing",
+  'test': "Publishing to Test",
+  'test-checks': "What to look for when testing",
+  'final-check': "Unlocking the ability to publish to Live",
+  'live': "Publishing to Live",
+  'live-checks': "What to check on Live",
+  'govuk': "Getting your form on GOV.UK",
+}} %>
+<section class="content-section content-section--with-top-border">
+  <h2 id="publishing-process" class="govuk-heading-m">Understanding the publishing process</h2>
+  <p>To see a fully working form that you can fill in and share with others, you have to publish it. MoJ Forms comes with both a Test site and Live site so that you can work on your form and only push changes live when you are happy with them. All changes made in the editor, including to settings, have to be published for them to take effect.<p>
+  <p>The Test site is for checking your form, sharing it with colleagues and stakeholders and gathering feedback. You can make multiple changes and updates to the Test site without needing to publish to Live. All test forms are protected by username and password, which you set when publishing.</p>
+  <p>The Live site is where your final form will live. This version can be shared with users and linked to from GOV.UK. You only need to publish to Live when you are happy with your form on the Test site. Live forms can be protected with a username and password if required.</p>
+  <p>Test forms have the URL: your-form-name.dev.form.service.justice.gov.uk<br>
+  Live forms have the URL: your-form-name.form.service.justice.gov.uk</p>
+  <p>Both the Test and Live sites:</p>
+  <ul>
+    <li>are on the internet, so there are no restrictions on who you can share the links with</li>
+    <li>will not be found and listed on search engines</li>
+  </ul>
+  <p><a class="govuk-link" href="#top">Back to top</a></p>
+</section>
+<section class="content-section content-section--with-top-border">
+  <h2 id="before-publishing" class="govuk-heading-m">Things to check before publishing</h2>
+  <p>The publishing page will check your form and warn you about some of the most common issues.</p>
+  <img src="/images/publishing-warnings.png" alt="A screenshot of the publishing page in MoJ Forms showing a publishing warning. A red arrow on the screenshot points to the warning which is above a blue button reading Publish to Test. The warning reads Which MoJ agency or body do you work for? has no autocomplete options and cannot be answered." class="screenshot-image">
+  <p>These checks include:</p> 
+  <ul>
+    <li>Whether you have enabled <a class="govuk-link" href="/settings/#email-settings">collecting information by email</a>. This is required if you want to receive any submissions from your form. It is also required if you want your form to send confirmation emails.</li>
+    <li>Whether your form contains a <a class="govuk-link" href="/building-and-editing/#check-confirm">check answers page and a confirmation page</a>. These are required if you want to receive any submissions from your form.</li>
+    <li>Whether you form includes any <a class="govuk-link" href="/building-and-editing/#autocomplete">autocomplete questions</a> without options. This means users will be unable to complete the question and could prevent them from completing your form.</li>
+  </ul>
+  <p>You will be able to publish your form to Test even with these issues but some features won't work.</p>
+  <p>However, you will not be able to publish a form to Live that contains an autocomplete question without any options. The button will be inactive (grey and unclickable) until this issue has been resolved.</p>
+  <p><a class="govuk-link" href="#top">Back to top</a></p>
+</section>
+<section class="content-section content-section--with-top-border">
+  <h2 id="test" class="govuk-heading-m">Publishing to Test</h2>
+  <p>To publish your form to the Test site, go to the publishing page and select 'publish to Test'. This will publish the version of your form in the editor to the Test site.</p>
+  <p>You will be asked to set a username and password for your form which will be required to view the form. All forms on the Test site are protected in this way. You will need to share these credentials with anyone you want to view the form.</p>
+  <p>If you forget what username and password you set, you can simply re-publish your form and set new details. These will replace your previous username and password.</p>
+  <p>It can take up to 15 minutes for the form to be visible the first time you publish it to Test. Updates are much quicker and should publish within a minute or less. (You may need to refresh your browser or clear your cache.)</p>
+  <img src="/images/publish-to-test.png" alt="The URL of a form is displayed on the publishing page after the form has been published." class="screenshot-image">
+  <p><a class="govuk-link" href="#top">Back to top</a></p>
+</section>
+<section class="content-section content-section--with-top-border">
+  <h2 id="test-checks" class="govuk-heading-m">What to look for when testing</h2>
+  <p>We recommend you always publish and test your form on the Test site before publishing to Live. Some of the things to look for are:</p>
+  <ul>
+    <li>any markdown you have used to format content is displaying correctly and any links are working as expected</li>
+    <li>questions are correctly flagged as optional or required</li>
+    <li>any branching within your form is working as expected</li>
+    <li>your form includes a check answers page and confirmation page if you want it to submit the data it collects</li>
+    <li>you are able to complete and submit a form using the Test URL</li>
+    <li>the submitted form content is going to the right email address</li>
+    <li>confirmation emails are being sent correctly if you have enabled this setting</li>
+    <li>your Google Analytics account is collecting data if you have enabled this setting (this can take up to 48 hours in Google Analytics 4)</li>
+  </ul>
+  <p>This is the time you should also start thinking about:</p> 
+  <ul>
+    <li>completing your <a class="govuk-link" href="/data-protection/#privacynotice">privacy notice template</a></li>
+    <li>conducting a <a class="govuk-link" href="/accessibility">basic accessibility check</a> and completing your <a class="govuk-link" href="/accessibility/#statement">accessibility statement</a></li>
+  </ul>
+  <p><a class="govuk-link" href="#top">Back to top</a></p>
+</section>
+<section class="content-section content-section--with-top-border">
+  <h2 id="final-check" class="govuk-heading-m">Unlocking the ability to publish to Live</h2>
+  <p>When you are satisfied that your form is ready, you need to apply to unlock the ability to publish to Live.</p>
+  <p>The MoJ Forms team will review your form against the MoJ Forms terms of use and confirm that:</p>
+  <ul>
+    <li>the form has been designed for legitimate purposes and not for illegal or inappropriate use</li>
+    <li>the privacy statement has been completely in full</li>
+    <li>the accessibility statement has been completed in full</li> 
+  </ul>
+  <p>This can take up to 3 working days.</p>
+  <p>The MoJ Forms team will then either unlock your ability to publish to Live or contact you to discuss any issues.</p>
+  <p>Once publishing to Live has been unlocked, you are free to publish your form at any time. You won't need to go through this process again for any future updates.</p>
+  <h3 class="govuk-heading-s">How to unlock publishing to Live</h3>
+  <p>When you are satisfied that your form is ready, go to the publishing page and select the 'Publish to Live' tab. If your form has not been published to Live yet, you will see a checklist of actions and a button labelled "Apply to unlock publishing".</p>  
+  <img src="/images/publishing-final-check.png" alt="A screenshot shows the MoJ Forms publishing page. The Publish to Live tab is active. A subheading reads Unlock publishing to Live and is followed by a checklist of actions." class="screenshot-image">
+  <p>Review the actions carefully and check each box to confirm that you have completed them before clicking "Apply to unlock publishing".</p>
+  <p>Normally, publishing will be unlocked within 3 working days and you will receive a confirmation by email. If there are any issues, a member of the MoJ Forms team will contact you directly.</p>
+  <p><a class="govuk-link" href="#top">Back to top</a></p>
+</section>
+<section class="content-section content-section--with-top-border">
+  <h2 id="live" class="govuk-heading-m">Publishing to Live</h2>
+  <p>To publish your form to the Live site, go to the publishing page and select the 'Publish to Live' tab. If you are publishing your form to Live for the first time, you will need to <a class="govuk-link" href="#final-check">apply to unlock publishing</a> first.</p>
+  <p>Once you have unlocked publishing, you will see a blue 'Publish to Live' button. If it is inactive (grey and unclickable) this means there are issues with your form that you will need to resolve before you can publish. See <a class="govuk-link" href="#before-publishing">things to check before publishing</a> for details.
+  <p>Publishing will promote the latest version of your form in the editor to the Live site.</p>
+  <p>After selecting 'Publish to Live', you will be presented with 2 options:</p>
+  <ul>
+    <li>allow anyone with the link to view</li>
+    <li>set a username and password</li>
+  </ul>
+  <p>If you set a username and password, you will need to share these with anyone you want to view the form. If you forget what username and password you set, you can simply re-publish your form and set new details. These will replace your previous username and password.</p>
+  <p>It can take up to 15 minutes for the form to be visible the first time you publish it to Live. Updates are much quicker and should appear within a minute or less. (You may need to refresh your browser or clear your cache.)</p>
+  <p><a class="govuk-link" href="#top">Back to top</a></p>
+</section>
+<section class="content-section content-section--with-top-border">
+  <h2 id="live-checks" class="govuk-heading-m">What to check on Live</h2>
+  <p>Always check your live form is working as expected before sharing with users. Some things to look for are:</p>
+  <ul>
+    <li>you are able to complete and submit a form using the Live URL</li>
+    <li>you are able to access the form without a username and password (unless you intend to keep the form password protected)</li>
+    <li>the submitted form content is going to the right email address</li>
+  </ul>
+  <p><a class="govuk-link" href="#top">Back to top</a></p>
+</section>
+<section class="content-section content-section--with-top-border">
+  <h2 id="govuk" class="govuk-heading-m">Getting your form on GOV.UK</h2>
+  <p>If you want to put your form on GOV.UK, you will need to talk to your local comms team. They will help you decide where the form should sit and help you with any guidance content that may be required around it.</p>
+  <p><a class="govuk-link" href="#top">Back to top</a></p>
+</section>

--- a/source/user-guide.html.erb
+++ b/source/user-guide.html.erb
@@ -5,62 +5,53 @@ category: user-guide
 order: 1
 menu: top
 menuindex: 3
+layout: user_guide
 ---
 
-<div class="govuk-width-container">
-  <main class="govuk-main-wrapper govuk-body" id="main-content" role="main">
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-one-quarter">
-        <%= partial "user_nav" %>
-      </div>
-      <div class="govuk-grid-column-three-quarters">
-        <h1 class="govuk-heading-l"><%= current_page.data.heading%></h1>
-        <!-- START CONTENT -->
-        <p class="govuk-body-l">Learn how to build, configure and publish forms and get help when you need it.</p>
-        <h2 class="govuk-heading-m">Contents</h2>
-        <%= partial "toc", locals: { links: { 
-          'access': "Getting access and signing in",
-          'issues': "Known issues",
-          'help': "Get help or report a bug",
-          'feedback': "Give feedabck"
-        }} %>
-      <section class="content-section content-section--with-top-border">
-        <h2 id="access" class="govuk-heading-m">Getting access and signing in</h2>
-        <p>MoJ Forms is only available to employees of MoJ and its agencies and public bodies. To request access, <a class="govuk-link" href="/contact">contact us</a> to discuss your requirements. As MoJ Forms is still in development, we need your consent to take part in ongoing research.</p>
-        <p>MoJ Forms shares a login with your primary work email address so you don't need to remember a separate username or password. We currently support email addresses ending in the following domains:</p>
-        <ul>
-        <li>@digital.justice.gov.uk</li>
-        <li>@justice.gov.uk</li>
-        <li>@cica.gov.uk</li>
-        <li>@judicialappointments.gov.uk</li>
-        <li>@judicialombudsman.gov.uk</li>
-        <li>@ospt.gov.uk</li>
-        <li>@ccrc.gov.uk</li>
-        <li>@hmcts.net</li>
-        </ul>
-        <p><a class="govuk-link" href="#top">Back to top</a></p>
-      </section>
-       <section class="content-section content-section--with-top-border">
-        <h2 id="issues" class="govuk-heading-m">Known issues</h2>
-        <p>MoJ Forms is a new platform with a range of features that we are working to expand. In the short term, you might encounter some limitations, including:
-        <ul>
-        <li>Forms cannot currently be deleted or unpublished (taken down from the internet). <a class="govuk-link" href="/contact/">Contact us</a> to do this.</li>
-        <li><a class="govuk-link" href="/building-and-editing/#autocomplete">Autocomplete questions</a> won't work if any of the uploaded answers contains an '&' symbol. Some other special characters may also cause problems. We recommend you use only standard letters in your answers.</li>
-        </ul>
-          <p><a class="govuk-link" href="#top">Back to top</a></p>
-      </section>
-      <section class="content-section content-section--with-top-border">
-          <h2 id="help" class="govuk-heading-m">Get help or report a bug</h2>
-        <p>If you need help doing something or think you have found a bug (something doesn’t work as you expected), <a class="govuk-link" href="/contact/">contact us by email or on Slack</a>.</p>
-        <p><a class="govuk-link" href="#top">Back to top</a></p>
-      </section>
-      <section class="content-section content-section--with-top-border">
-        <h2 id="feedback" class="govuk-heading-m">Give feedback</h2>
-        <p><a class="govuk-link" href="/contact/">Contact us by email or on Slack</a> to tell us what you think of MoJ Forms and suggest improvements.</p>
-        <p><a class="govuk-link" href="#top">Back to top</a></p>
-      </section>
-        <!-- END CONTENT -->
-      </div>
-    </div>
-  </main>
-</div>
+
+<h1 class="govuk-heading-l"><%= current_page.data.heading%></h1>
+<!-- START CONTENT -->
+<p class="govuk-body-l">Learn how to build, configure and publish forms and get help when you need it.</p>
+<h2 class="govuk-heading-m">Contents</h2>
+<%= partial "toc", locals: { links: { 
+  'access': "Getting access and signing in",
+  'issues': "Known issues",
+  'help': "Get help or report a bug",
+  'feedback': "Give feedabck"
+}} %>
+<section class="content-section content-section--with-top-border">
+  <h2 id="access" class="govuk-heading-m">Getting access and signing in</h2>
+  <p>MoJ Forms is only available to employees of MoJ and its agencies and public bodies. To request access, <a class="govuk-link" href="/contact">contact us</a> to discuss your requirements. As MoJ Forms is still in development, we need your consent to take part in ongoing research.</p>
+  <p>MoJ Forms shares a login with your primary work email address so you don't need to remember a separate username or password. We currently support email addresses ending in the following domains:</p>
+  <ul>
+  <li>@digital.justice.gov.uk</li>
+  <li>@justice.gov.uk</li>
+  <li>@cica.gov.uk</li>
+  <li>@judicialappointments.gov.uk</li>
+  <li>@judicialombudsman.gov.uk</li>
+  <li>@ospt.gov.uk</li>
+  <li>@ccrc.gov.uk</li>
+  <li>@hmcts.net</li>
+  </ul>
+  <p><a class="govuk-link" href="#top">Back to top</a></p>
+</section>
+<section class="content-section content-section--with-top-border">
+<h2 id="issues" class="govuk-heading-m">Known issues</h2>
+<p>MoJ Forms is a new platform with a range of features that we are working to expand. In the short term, you might encounter some limitations, including:
+<ul>
+<li>Forms cannot currently be deleted or unpublished (taken down from the internet). <a class="govuk-link" href="/contact/">Contact us</a> to do this.</li>
+<li><a class="govuk-link" href="/building-and-editing/#autocomplete">Autocomplete questions</a> won't work if any of the uploaded answers contains an '&' symbol. Some other special characters may also cause problems. We recommend you use only standard letters in your answers.</li>
+</ul>
+  <p><a class="govuk-link" href="#top">Back to top</a></p>
+</section>
+<section class="content-section content-section--with-top-border">
+  <h2 id="help" class="govuk-heading-m">Get help or report a bug</h2>
+<p>If you need help doing something or think you have found a bug (something doesn’t work as you expected), <a class="govuk-link" href="/contact/">contact us by email or on Slack</a>.</p>
+<p><a class="govuk-link" href="#top">Back to top</a></p>
+</section>
+<section class="content-section content-section--with-top-border">
+<h2 id="feedback" class="govuk-heading-m">Give feedback</h2>
+<p><a class="govuk-link" href="/contact/">Contact us by email or on Slack</a> to tell us what you think of MoJ Forms and suggest improvements.</p>
+<p><a class="govuk-link" href="#top">Back to top</a></p>
+</section>
+


### PR DESCRIPTION
This PR fixes a couple fo small accessibility issues with the product site user guide navigation.
1) It moves the side navigation out of the `<main>` element - meaning the 'skip to content' link actually skips all repeated navigation (as it should)
2) It updates the side navigation to semantically be a list, rather than a series of paragraphs.

In order to easily do item 1 a new nested `user_guide.erb` layout was created, allowing all user guide pages to use the same structure (and avoid repeated markup in the content files)