### PR TITLE
Add larger margin above h3s in body text

### DIFF
--- a/source/stylesheets/application.css.scss
+++ b/source/stylesheets/application.css.scss
@@ -68,6 +68,11 @@ p.govuk-body,
   max-width: 75ch;
 }
 
+.govuk-body p + h3,
+.govuk-body ul + h3 {
+  margin-top: 2em;
+}
+
 .screenshot-image {
   width: 100%;
   border: 1px solid #ccc;


### PR DESCRIPTION
Adds a bit more spacing above H3 headings within body text to aid clarity.

**Before:**
![image](https://github.com/ministryofjustice/formbuilder-product-page/assets/595564/83fdd317-f0c5-4978-8a8b-4a5da6bf5a6d)

**After:**
![image](https://github.com/ministryofjustice/formbuilder-product-page/assets/595564/33e71ea8-2abc-4a80-8c1b-471ff0b4ad80)
