### PR TITLE
Add no index meta tag

### DIFF
--- a/source/contact.html.erb
+++ b/source/contact.html.erb
@@ -34,8 +34,6 @@ menuindex: 4
               <li>screenshots of any relevant pages and messages</li>
               </ul>
               <p>We will respond as soon as possible. Our working hours are Monday to Friday, 9am to 5pm, excluding bank holidays.</p>
-            <h2>Help make MoJ Forms better</h2>
-            <p><a class="govuk-link" href="https://mojf-ur-panel.form.service.justice.gov.uk/">Sign up to take part in MoJ Forms user research</a></p>
         </div>
       </div>
     </section>

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -13,6 +13,7 @@
     <link rel="apple-touch-icon" sizes="152x152" href="/images/govuk-apple-touch-icon-152x152.png">
     <link rel="apple-touch-icon" href="/images/govuk-apple-touch-icon.png">
     <meta property="og:image" content="/images/govuk-opengraph-image.png">
+    <meta name="robots" content="noindex">
 
     <%= stylesheet_link_tag :application, media: 'screen' %>
     <%= javascript_include_tag :application %>


### PR DESCRIPTION
The product page won't need to be search engine discoverable for the remainder of the platform's lifecycle so this may cut down slightly on the number of unrelated emails received to the mailbox published on the product site.

We're also slowing down onboarding internally so sharing the product site link directly when necessary will be fine.