### PR TITLE
Reopen jan 2026

### DIFF
--- a/source/govuk-and-moj-forms.html.erb
+++ b/source/govuk-and-moj-forms.html.erb
@@ -1,0 +1,107 @@
+---
+title: Choosing between GOV.UK Forms and MoJ Forms
+heading: Choosing between GOV.UK Forms and MoJ Forms
+---
+
+<div class="govuk-width-container">
+  <main class="govuk-main-wrapper govuk-body" id="main-content" role="main">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-full">
+        <h1 class="govuk-heading-l"><%= current_page.data.heading %></h1>
+
+        
+        <!-- START CONTENT -->
+        <p class="govuk-body">MoJ Forms is not the only form-building platform available to teams at the Ministry of Justice and its agencies and public bodies. Any central government team also has access to <a class="govuk-link" href="https://www.forms.service.gov.uk/">GOV.UK Forms</a>.</p>
+        <p class="govuk-body">GOV.UK Forms is a government-wide form-building service built by the Government Digital Service (GDS). It should be a team’s first choice of form-building platform. MoJ Forms should generally only be used when GOV.UK Forms is unsuitable.</p>
+        <section class="content-section content-section--with-top-border">
+          <h2 id="compare" class="govuk-heading-m">Compare GOV.UK Forms and MoJ Forms</h2>
+          <p class="govuk-body">This is only a basic comparison of the platforms. Refer to the GOV.UK Forms website for a full and up-to-date list of that platform’s features and capabilities.</p>
+          <h3 id="features" class="govuk-heading-s">Table: GOV.UK Forms and MoJ Forms features</h3>
+          <table style="font-family: Arial, Helvetica, sans-serif; text-align: left; border:1px solid #dee0e2;" border="1">
+    <thead>
+    <thead>
+        <tr>
+            <th>Feature</th>
+            <th>GOV.UK Forms</th>
+            <th>MoJ Forms</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <th>Platform access</th>
+            <td>Any central government organisation</td>
+            <td>MoJ agencies and public bodies</td>
+        </tr>
+        <tr>
+            <th>Cost</th>
+            <td>Free</td>
+            <td>Free</td>
+        </tr>
+        <tr>
+            <th>Number of forms</th>
+            <td>Unlimited</td>
+            <td>Unlimited</td>
+        </tr>
+        <tr>
+            <th>Form access</th>
+            <td>Multiple editors per form</td>
+            <td>Single editor per form</td>
+        </tr>
+        <tr>
+            <th>Appearance</th>
+            <td>GOV.UK Design System</td>
+            <td>GOV.UK Design System</td>
+        </tr>
+        <tr>
+            <th>Accessibility</th>
+            <td>WCAG compliant</td>
+            <td>WCAG compliant</td>
+        </tr>
+        <tr>
+            <th>Start page</th>
+            <td>Requires separate GOV.UK start page</td>
+            <td>Included</td>
+        </tr>
+        <tr>
+            <th>Question format</th>
+            <td>One question per page</td>
+            <td>Flexible</td>
+        </tr>
+        <tr>
+            <th>Form complexity</th>
+            <td>Up to 2 routes</td>
+            <td>Unlimited branches</td>
+        </tr>
+        <tr>
+            <th>Submission options</th>
+            <td>Email attachment, AWS S3 bucket</td>
+            <td>Email body, email attachment, MS Lists</td>
+        </tr>
+        <tr>
+            <th>GOV.UK Pay integration</th>
+            <td>Yes</td>
+            <td>Yes</td>
+        </tr>
+        <tr>
+            <th>Save progress</th>
+            <td>Upcoming</td>
+            <td>Yes</td>
+        </tr>
+        <tr>
+            <th>Welsh versions</th>
+            <td>Upcoming</td>
+            <td>Supported</td>
+        </tr>
+        <tr>
+            <th>Metrics</th>
+            <td>Included</td>
+            <td>Via Google Analytics</td>
+        </tr>
+    </tbody>
+</table>
+        </section>
+        <!-- END CONTENT -->
+      </div>
+    </div>
+  </main>
+</div>

--- a/source/govuk-and-moj-forms.html.erb
+++ b/source/govuk-and-moj-forms.html.erb
@@ -12,7 +12,8 @@ heading: Choosing between GOV.UK Forms and MoJ Forms
         
         <!-- START CONTENT -->
         <p class="govuk-body">MoJ Forms is not the only form-building platform available to teams at the Ministry of Justice and its agencies and public bodies. Any central government team also has access to <a class="govuk-link" href="https://www.forms.service.gov.uk/">GOV.UK Forms</a>.</p>
-        <p class="govuk-body">GOV.UK Forms is a government-wide form-building service built by the Government Digital Service (GDS). It should be a team's choice for building simple and straightforward forms. MoJ Forms should generally be used for more complex forms and when GOV.UK Forms is unsuitable.</p>
+        <p class="govuk-body">GOV.UK Forms is a government-wide form-building service built by the Government Digital Service (GDS).</p>
+        <p class="govuk-body"> GOV.UK Forms should be a team's choice for building simple and straightforward forms. MoJ Forms should generally be used for more complex forms and when GOV.UK Forms is unsuitable.</p>
         <section class="content-section content-section--with-top-border">
           <h2 id="compare" class="govuk-heading-m">Compare GOV.UK Forms and MoJ Forms</h2>
           <p class="govuk-body">This is only a basic comparison of the platforms. Refer to the GOV.UK Forms website for a full and up-to-date list of that platform’s features and capabilities.</p>

--- a/source/govuk-and-moj-forms.html.erb
+++ b/source/govuk-and-moj-forms.html.erb
@@ -12,7 +12,7 @@ heading: Choosing between GOV.UK Forms and MoJ Forms
         
         <!-- START CONTENT -->
         <p class="govuk-body">MoJ Forms is not the only form-building platform available to teams at the Ministry of Justice and its agencies and public bodies. Any central government team also has access to <a class="govuk-link" href="https://www.forms.service.gov.uk/">GOV.UK Forms</a>.</p>
-        <p class="govuk-body">GOV.UK Forms is a government-wide form-building service built by the Government Digital Service (GDS). It should be a team’s first choice of form-building platform. MoJ Forms should generally only be used when GOV.UK Forms is unsuitable.</p>
+        <p class="govuk-body">GOV.UK Forms is a government-wide form-building service built by the Government Digital Service (GDS). It should be a team's choice for building simple and straightforward forms. MoJ Forms should generally be used for more complex forms and when GOV.UK Forms is unsuitable.</p>
         <section class="content-section content-section--with-top-border">
           <h2 id="compare" class="govuk-heading-m">Compare GOV.UK Forms and MoJ Forms</h2>
           <p class="govuk-body">This is only a basic comparison of the platforms. Refer to the GOV.UK Forms website for a full and up-to-date list of that platform’s features and capabilities.</p>

--- a/source/govuk-and-moj-forms.html.erb
+++ b/source/govuk-and-moj-forms.html.erb
@@ -11,12 +11,13 @@ heading: Choosing between GOV.UK Forms and MoJ Forms
 
         
         <!-- START CONTENT -->
-        <p class="govuk-body">You can create online forms using either MoJ Forms or <a class="govuk-link" href="https://www.forms.service.gov.uk/">GOV.UK Forms</a>. GOV.UK Forms is a government-wide form-building service built by the Government Digital Service (GDS).</p>
-        <p class="govuk-body">The right platform depends on how simple or complex your form needs to be:
+        <p class="govuk-body">You can create online forms using either MoJ Forms or <a class="govuk-link" href="https://www.forms.service.gov.uk/">GOV.UK Forms</a>.
+        <p class="govuk-body">The right platform depends on how simple or complex your form needs to be:</p>
         <ul>
         <li>use GOV.UK Forms for straightforward forms with limited branching and a standard GOV.UK layout</li>
         <li>use MoJ Forms when you need more advanced features, such as flexible layouts, unlimited branching, Welsh versions, or MS Lists integration</li>
         </ul>
+        <section class="content-section content-section--with-top-border">
           <h2 id="compare" class="govuk-heading-m">Compare GOV.UK Forms and MoJ Forms</h2>
           <p class="govuk-body">This is only a basic comparison of the platforms. Refer to the <a class="govuk-link" href="https://www.forms.service.gov.uk/">GOV.UK Forms website</a> for a full and up-to-date list of that platform’s features and capabilities.</p>
           <table class="govuk-table">
@@ -102,6 +103,7 @@ heading: Choosing between GOV.UK Forms and MoJ Forms
     </tbody>
 </table>
 <p class="govuk-body"><a class="govuk-link" href="/contact">Contact us</a> if you want to discuss your requirements or need help deciding which platform to use.</p>
+</section>
         </section>
         <!-- END CONTENT -->
       </div>

--- a/source/govuk-and-moj-forms.html.erb
+++ b/source/govuk-and-moj-forms.html.erb
@@ -15,7 +15,7 @@ heading: Choosing between GOV.UK Forms and MoJ Forms
         <p class="govuk-body">The right platform depends on how simple or complex your form needs to be:</p>
         <ul>
         <li>use GOV.UK Forms for straightforward forms with limited branching and a standard GOV.UK layout</li>
-        <li>use MoJ Forms when you need more advanced features, such as flexible layouts, unlimited branching, Welsh versions, or MS Lists integration</li>
+        <li>use MoJ Forms when you need more advanced features, such as flexible layouts, unlimited branching or MS Lists integration</li>
         </ul>
         <section class="content-section content-section--with-top-border">
           <h2 id="compare" class="govuk-heading-m">Compare GOV.UK Forms and MoJ Forms</h2>
@@ -86,14 +86,14 @@ heading: Choosing between GOV.UK Forms and MoJ Forms
             <td class="govuk-table__cell">Yes</td>
         </tr>
         <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header">Save progress</th>
-            <td class="govuk-table__cell">Upcoming</td>
+            <th scope="row" class="govuk-table__header">Welsh language support</th>
+            <td class="govuk-table__cell">Yes</td>
             <td class="govuk-table__cell">Yes</td>
         </tr>
         <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header">Welsh versions</th>
+            <th scope="row" class="govuk-table__header">Save progress</th>
             <td class="govuk-table__cell">Upcoming</td>
-            <td class="govuk-table__cell">Supported</td>
+            <td class="govuk-table__cell">Yes</td>
         </tr>
         <tr class="govuk-table__row">
             <th scope="row" class="govuk-table__header">Metrics</th>

--- a/source/govuk-and-moj-forms.html.erb
+++ b/source/govuk-and-moj-forms.html.erb
@@ -16,86 +16,89 @@ heading: Choosing between GOV.UK Forms and MoJ Forms
         <section class="content-section content-section--with-top-border">
           <h2 id="compare" class="govuk-heading-m">Compare GOV.UK Forms and MoJ Forms</h2>
           <p class="govuk-body">This is only a basic comparison of the platforms. Refer to the GOV.UK Forms website for a full and up-to-date list of that platform’s features and capabilities.</p>
-          <h3 id="features" class="govuk-heading-s">Table: GOV.UK Forms and MoJ Forms features</h3>
-          <table style="font-family: Arial, Helvetica, sans-serif; text-align: left; border:1px solid #dee0e2;" border="1">
-    <thead>
-    <thead>
-        <tr>
-            <th>Feature</th>
-            <th>GOV.UK Forms</th>
-            <th>MoJ Forms</th>
+
+          
+          
+          
+    <table class="govuk-table">
+        <caption class="govuk-table__caption govuk-table__caption--m">GOV.UK Forms and MoJ Forms features</caption>
+        <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+            <th scope="col" class="govuk-table__header">Feature</th>
+            <th scope="col" class="govuk-table__header">GOV.UK Forms</th>
+            <th scope="col" class="govuk-table__header">MoJ Forms</th>
         </tr>
     </thead>
-    <tbody>
-        <tr>
-            <th>Platform access</th>
-            <td>Any central government organisation</td>
-            <td>MoJ agencies and public bodies</td>
+    <tbody class="govuk-table__body">
+        <tr class="govuk-table__row">
+            <th scope="row" class="govuk-table__header">Platform access</th>
+            <td class="govuk-table__cell">Any central government organisation</td>
+            <td class="govuk-table__cell">MoJ agencies and public bodies</td>
         </tr>
-        <tr>
-            <th>Cost</th>
-            <td>Free</td>
-            <td>Free</td>
+        <tr class="govuk-table__row">
+            <th scope="row" class="govuk-table__header">Cost</th>
+            <td class="govuk-table__cell">Free</td>
+            <td class="govuk-table__cell">Free</td>
         </tr>
-        <tr>
-            <th>Number of forms</th>
-            <td>Unlimited</td>
-            <td>Unlimited</td>
+        <tr class="govuk-table__row">
+            <th scope="row" class="govuk-table__header">Number of forms</th>
+            <td class="govuk-table__cell">Unlimited</td>
+            <td class="govuk-table__cell">Unlimited</td>
         </tr>
-        <tr>
-            <th>Form access</th>
-            <td>Multiple editors per form</td>
-            <td>Single editor per form</td>
+        <tr class="govuk-table__row">
+            <th scope="row" class="govuk-table__header">Form access</th>
+            <td class="govuk-table__cell">Multiple editors per form</td>
+            <td class="govuk-table__cell">Single editor per form</td>
         </tr>
-        <tr>
-            <th>Appearance</th>
-            <td>GOV.UK Design System</td>
-            <td>GOV.UK Design System</td>
+        <tr class="govuk-table__row">
+            <th scope="row" class="govuk-table__header">Appearance</th>
+            <td class="govuk-table__cell">GOV.UK Design System</td>
+            <td class="govuk-table__cell">GOV.UK Design System</td>
         </tr>
-        <tr>
-            <th>Accessibility</th>
-            <td>WCAG compliant</td>
-            <td>WCAG compliant</td>
+        <tr class="govuk-table__row">
+            <th scope="row" class="govuk-table__header">Accessibility</th>
+            <td class="govuk-table__cell">WCAG compliant</td>
+            <td class="govuk-table__cell">WCAG compliant</td>
         </tr>
-        <tr>
-            <th>Start page</th>
-            <td>Requires separate GOV.UK start page</td>
-            <td>Included</td>
+        <tr class="govuk-table__row">
+            <th scope="row" class="govuk-table__header">Start page</th>
+            <td class="govuk-table__cell">Requires separate GOV.UK start page</td>
+            <td class="govuk-table__cell">Included</td>
         </tr>
-        <tr>
-            <th>Question format</th>
-            <td>One question per page</td>
-            <td>Flexible</td>
+        <tr class="govuk-table__row">
+            <th scope="row" class="govuk-table__header">Question format</th>
+            <td class="govuk-table__cell">One question per page</td>
+            <td class="govuk-table__cell">Flexible</td>
         </tr>
-        <tr>
-            <th>Form complexity</th>
-            <td>Up to 2 routes</td>
-            <td>Unlimited branches</td>
+        <tr class="govuk-table__row">
+            <th scope="row" class="govuk-table__header">Form complexity</th>
+            <td class="govuk-table__cell">Up to 2 routes</td>
+            <td class="govuk-table__cell">Unlimited branches</td>
         </tr>
-        <tr>
-            <th>Submission options</th>
-            <td>Email attachment, AWS S3 bucket</td>
-            <td>Email body, email attachment, MS Lists</td>
+        <tr class="govuk-table__row">
+            <th scope="row" class="govuk-table__header">Submission options</th>
+            <td class="govuk-table__cell">Email attachment, AWS S3 bucket</td>
+            <td class="govuk-table__cell">Email body, email attachment, MS Lists</td>
         </tr>
-        <tr>
-            <th>GOV.UK Pay integration</th>
-            <td>Yes</td>
-            <td>Yes</td>
+        <tr class="govuk-table__row">
+            <th scope="row" class="govuk-table__header">GOV.UK Pay integration</th>
+            <td class="govuk-table__cell">Yes</td>
+            <td class="govuk-table__cell">Yes</td>
         </tr>
-        <tr>
-            <th>Save progress</th>
-            <td>Upcoming</td>
-            <td>Yes</td>
+        <tr class="govuk-table__row">
+            <th scope="row" class="govuk-table__header">Save progress</th>
+            <td class="govuk-table__cell">Upcoming</td>
+            <td class="govuk-table__cell">Yes</td>
         </tr>
-        <tr>
-            <th>Welsh versions</th>
-            <td>Upcoming</td>
-            <td>Supported</td>
+        <tr class="govuk-table__row">
+            <th scope="row" class="govuk-table__header">Welsh versions</th>
+            <td class="govuk-table__cell">Upcoming</td>
+            <td class="govuk-table__cell">Supported</td>
         </tr>
-        <tr>
-            <th>Metrics</th>
-            <td>Included</td>
-            <td>Via Google Analytics</td>
+        <tr class="govuk-table__row">
+            <th scope="row" class="govuk-table__header">Metrics</th>
+            <td class="govuk-table__cell">Included</td>
+            <td class="govuk-table__cell">Via Google Analytics</td>
         </tr>
     </tbody>
 </table>

--- a/source/govuk-and-moj-forms.html.erb
+++ b/source/govuk-and-moj-forms.html.erb
@@ -11,18 +11,16 @@ heading: Choosing between GOV.UK Forms and MoJ Forms
 
         
         <!-- START CONTENT -->
-        <p class="govuk-body">MoJ Forms is not the only form-building platform available to teams at the Ministry of Justice and its agencies and public bodies. Any central government team also has access to <a class="govuk-link" href="https://www.forms.service.gov.uk/">GOV.UK Forms</a>.</p>
-        <p class="govuk-body">GOV.UK Forms is a government-wide form-building service built by the Government Digital Service (GDS).</p>
-        <p class="govuk-body"> GOV.UK Forms should be a team's choice for building simple and straightforward forms. MoJ Forms should generally be used for more complex forms and when GOV.UK Forms is unsuitable.</p>
-        <section class="content-section content-section--with-top-border">
+        <p class="govuk-body">You can create online forms using either MoJ Forms or <a class="govuk-link" href="https://www.forms.service.gov.uk/">GOV.UK Forms</a>. GOV.UK Forms is a government-wide form-building service built by the Government Digital Service (GDS).</p>
+        <p class="govuk-body">The right platform depends on how simple or complex your form needs to be:
+        <ul>
+        <li>use GOV.UK Forms for straightforward forms with limited branching and a standard GOV.UK layout</li>
+        <li>use MoJ Forms when you need more advanced features, such as flexible layouts, unlimited branching, Welsh versions, or MS Lists integration</li>
+        </ul>
           <h2 id="compare" class="govuk-heading-m">Compare GOV.UK Forms and MoJ Forms</h2>
-          <p class="govuk-body">This is only a basic comparison of the platforms. Refer to the GOV.UK Forms website for a full and up-to-date list of that platform’s features and capabilities.</p>
-
-          
-          
-          
-    <table class="govuk-table">
-        <caption class="govuk-table__caption govuk-table__caption--m">GOV.UK Forms and MoJ Forms features</caption>
+          <p class="govuk-body">This is only a basic comparison of the platforms. Refer to the <a class="govuk-link" href="https://www.forms.service.gov.uk/">GOV.UK Forms website</a> for a full and up-to-date list of that platform’s features and capabilities.</p>
+          <table class="govuk-table">
+        <caption class="govuk-table__caption govuk-table__caption--s">GOV.UK Forms and MoJ Forms features</caption>
         <thead class="govuk-table__head">
         <tr class="govuk-table__row">
             <th scope="col" class="govuk-table__header">Feature</th>
@@ -103,6 +101,7 @@ heading: Choosing between GOV.UK Forms and MoJ Forms
         </tr>
     </tbody>
 </table>
+<p class="govuk-body"><a class="govuk-link" href="/contact">Contact us</a> if you want to discuss your requirements or need help deciding which platform to use.</p>
         </section>
         <!-- END CONTENT -->
       </div>

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -63,7 +63,7 @@ title: MoJ Forms
       </div>
     </div>
   </section>
-  <section class="content-section">
+  <section class="content-section content-section--with-top-border">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <h2 class="govuk-heading-m">When to use MoJ Forms</h2>

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -14,16 +14,6 @@ title: MoJ Forms
 </div>
 <main class="govuk-main-wrapper govuk-body" id="main-content" role="main">
   <div class="govuk-width-container">
-  <section class="content-section">
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
-      <h2 class="govuk-heading-m">MoJ Forms is being retired</h2>
-      <p class="govuk-body">MoJ's primary form building platform is now <a class="govuk-link" href="https://www.forms.service.gov.uk/">GOV.UK Forms</a>. We are no longer accepting new forms or new users on MoJ Forms.</p>
-      <p class="govuk-body">We are currently working on plans to migrate all existing forms off the platform.  MoJ Forms will be maintained and supported throughout this period.</p>
-      <p class="govuk-body">Read the <a class="govuk-link" href="/news#next-steps-retiring-10062025">latest update on our migration plans</a>.</p>
-    </div>
-  </div>
-</section>
     <section class="content-section content-section--with-top-border">
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-one-half">
@@ -73,6 +63,22 @@ title: MoJ Forms
       </div>
     </div>
   </section>
+  <section class="content-section">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <h2 class="govuk-heading-m">When to use MoJ Forms</h2>
+      <p class="govuk-body">MoJ Forms should be considered alongside <a class="govuk-link" href="https://www.forms.service.gov.uk/">GOV.UK Forms</a> – a separate form-building platform from the Government Digital Service (GDS).</p>
+      <p class="govuk-body">GOV.UK Forms can be used for a wide variety of forms that:</p>
+      <ul>
+      <li>sit on GOV.UK</li>
+      <li>need standard form components like text fields and radio buttons</li>
+      <li>need 1 or 2 branches</li>
+      </ul>
+      <p class="govuk-body">MoJ Forms should generally be used only for more complex forms when GOV.UK Forms is unsuitable.</p>
+      <p class="govuk-body">Find out more about <a class="govuk-link" href="/govuk-and-moj-forms">choosing between GOV.UK Forms and MoJ Forms</a>.</p>
+    </div>
+  </div>
+</section>
   </div>
 </main>
 

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -74,7 +74,7 @@ title: MoJ Forms
       <li>need standard form components like text fields and radio buttons</li>
       <li>need 1 or 2 branches</li>
       </ul>
-      <p class="govuk-body">MoJ Forms should generally be used only for more complex forms when GOV.UK Forms is unsuitable.</p>
+      <p class="govuk-body">MoJ Forms should be a team's choice for building simple and straightforward forms. MoJ Forms should generally be used for more complex forms and when GOV.UK Forms is unsuitable.</p>
       <p class="govuk-body">Find out more about <a class="govuk-link" href="/govuk-and-moj-forms">choosing between GOV.UK Forms and MoJ Forms</a>.</p>
     </div>
   </div>

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -74,7 +74,7 @@ title: MoJ Forms
       <li>need standard form components like text fields and radio buttons</li>
       <li>need 1 or 2 branches</li>
       </ul>
-      <p class="govuk-body">MoJ Forms should be a team's choice for building simple and straightforward forms. MoJ Forms should generally be used for more complex forms and when GOV.UK Forms is unsuitable.</p>
+      <p class="govuk-body">GOV.UK Forms should be a team's choice for building simple and straightforward forms. MoJ Forms should generally be used for more complex forms and when GOV.UK Forms is unsuitable.</p>
       <p class="govuk-body">Find out more about <a class="govuk-link" href="/govuk-and-moj-forms">choosing between GOV.UK Forms and MoJ Forms</a>.</p>
     </div>
   </div>

--- a/source/news.html.erb
+++ b/source/news.html.erb
@@ -14,7 +14,26 @@ menuindex: 2
     </div>
   </div>
   </section>
- 
+<section class="content-section content-section--with-top-border">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+    <p>3 October 2025</p>
+    <h2 id="long-term-changes-03102025" class="govuk-heading-m">Long-term changes for MoJ Forms</h2>
+    <p>The Ministry of Justice has reversed its decision to retire MoJ Forms and decided to retain the platform long term. This follows a wide range of views and concerns by users. We recognise that MoJ Forms performs a vital role in your services that is hard to replace. We also believe there is still a role for the platform in supporting our digital strategy.</p>
+    <h3 class="govuk-heading-s">New direction</h3>
+    <p><a class="govuk-link" href="https://www.forms.service.gov.uk/">GOV.UK Forms</a> is still the department’s primary form building platform. For simple forms, it’s the best solution. However, MoJ Forms supports a level of complexity above and beyond what GOV.UK Forms is designed to enable, particularly in the number of pages and branching options.</p>
+    <p>With clear positioning, we believe there is room for both platforms. This decision means we can reinvest in MoJ Forms in a focused and strategic way to ensure it provides the most value without duplicating the brilliant work at GDS.</p>
+    <h3 class="govuk-heading-s">Next steps</h3>
+    <p>Our first task is to clearly articulate the positioning between GOV.UK Forms and MoJ Forms. We will then create a means to help owners choose the best approach for them. Once this work is mature, we will publish timescales for re-establishing the form creation.</p>
+    <p>We will also be reinvesting in the platform’s technology to ensure it remains stable and secure.</p>
+    <p>At the same time, we plan to work with the Service Standards and Assurance team on a process for assessing and ensuring the quality of new forms.</p>
+    <h3 class="govuk-heading-s">What this means for your forms</h3>
+    <p>For now, there is no change. Your forms will continue to be supported on MoJ Forms. In the longer term, we will identify which forms will be better served on GOV.UK Forms or another platform and work with the owners to enable that migration.</p>
+    <p>We recognise that this has been an uncertain time for some of you and apologise for the ongoing lack of clarity. MoJ Forms now has a certain future, and we look forward to working with you to shape it and providing regular updates for you all.</p>
+    <p><a class="govuk-link" href="#top">Back to top</a></p>
+    </div>
+  </div>
+</section>
   <section class="content-section content-section--with-top-border">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
@@ -33,7 +52,6 @@ menuindex: 2
     </div>
   </div>
 </section>
-
 <section class="content-section content-section--with-top-border">
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">

--- a/source/sitemap.html.erb
+++ b/source/sitemap.html.erb
@@ -17,6 +17,9 @@ menuindex: 4
             <a class="govuk-link" href="/">Home</a>
           </li>
           <li>
+            <a class="govuk-link" href="/govuk-and-moj-forms">Choosing between GOV.UK Forms and MoJ Forms</a>
+          </li>
+          <li>
             <a class="govuk-link" href="/news">News</a>
             <ul class="govuk-list govuk-!-margin-left-4">
               <% sitemap.resources.filter { |item| item.data[:menu] != 'top' && item.path.to_s.include?('news') }.sort { |a, b| b.data.title <=> a.data.title }.each do |item| %>

--- a/source/stylesheets/application.css.scss
+++ b/source/stylesheets/application.css.scss
@@ -41,14 +41,7 @@ $govuk-font-family: Arial, Helvetica, sans-serif;
   color: #fff;
 }
 
-table,
-th,
-td {
-  border-collapse: collapse;
-  border: 1px solid #dee0e2;
-  vertical-align: top;
-  padding: 15px;
-}
+
 
 .govuk-heading-xl,
 .govuk-heading-l,

--- a/source/user-guide.html.erb
+++ b/source/user-guide.html.erb
@@ -20,13 +20,23 @@ layout: user_guide
 }} %>
 <section class="content-section content-section--with-top-border">
   <h2 id="requirements" class="govuk-heading-m">Requirements for forms</h2>
-  <p>THIS IS A NEW SECTION content TBC</p>
-  <p><a class="govuk-link" href="#top">Back to top</a></p>
+  <p class="govuk-body">Forms built on MoJ Forms must meet our requirements. We review these aspects of your form when deciding whether to approve a request to unlock publishing and make a form live.</p>
+  <h3 class="govuk-heading-s">You must consider and rule out GOV.UK Forms before choosing MoJ Forms</h3>
+  <p class="govuk-body"><a class="govuk-link" href="https://www.forms.service.gov.uk/">GOV.UK Forms</a> is a government-wide form-building service from the Government Digital Service (GDS). It should be your first choice for building simple and straightforward forms. MoJ Forms should generally be used for more complex forms when GOV.UK Forms is unsuitable. Find out more about <a class="govuk-link" href="/govuk-and-moj-forms">choosing between GOV.UK Forms and MoJ Forms</a>.</p>
+  <h3 class="govuk-heading-s">You must accept and comply with the MoJ Forms terms of us</h3>
+  <p class="govuk-body">The <a class="govuk-link" href="/terms-of-use"> MoJ Forms terms of use</a> apply to all forms built on the platform. They describe your responsibilities as a user of MoJ Forms and describe how forms must:</p>
+  <ul>
+  <li>be used for legitimate MoJ purposes</li>
+  <li>comply with data protection guidelines and regulations</li>
+  <li>comply with accessibility guidelines and regulations</li>
+  <li>be maintained and managed through its lifetime</li>
+  </ul>
+  <p class="govuk-body"><a class="govuk-link" href="#top">Back to top</a></p>
 </section>
 <section class="content-section content-section--with-top-border">
   <h2 id="access" class="govuk-heading-m">Getting access and signing in</h2>
-  <p>MoJ Forms is only available to employees of MoJ and its agencies and public bodies. To request access, <a class="govuk-link" href="/contact">contact us</a> to discuss your requirements. As MoJ Forms is still in development, we need your consent to take part in ongoing research.</p>
-  <p>MoJ Forms shares a login with your primary work email address so you don't need to remember a separate username or password. We currently support email addresses ending in the following domains:</p>
+  <p class="govuk-body">MoJ Forms is only available to employees of MoJ and its agencies and public bodies. To request access, <a class="govuk-link" href="/contact">contact us</a> to discuss your requirements. As MoJ Forms is still in development, we need your consent to take part in ongoing research.</p>
+  <p class="govuk-body">MoJ Forms shares a login with your primary work email address so you don't need to remember a separate username or password. We currently support email addresses ending in the following domains:</p>
   <ul>
   <li>@digital.justice.gov.uk</li>
   <li>@justice.gov.uk</li>
@@ -37,25 +47,25 @@ layout: user_guide
   <li>@ccrc.gov.uk</li>
   <li>@hmcts.net</li>
   </ul>
-  <p><a class="govuk-link" href="#top">Back to top</a></p>
+  <p class="govuk-body"><a class="govuk-link" href="#top">Back to top</a></p>
 </section>
 <section class="content-section content-section--with-top-border">
 <h2 id="issues" class="govuk-heading-m">Known issues</h2>
-<p>MoJ Forms is a new platform with a range of features that we are working to expand. In the short term, you might encounter some limitations, including:
+<p class="govuk-body">MoJ Forms is a new platform with a range of features that we are working to expand. In the short term, you might encounter some limitations, including:
 <ul>
 <li>Forms cannot currently be deleted or unpublished (taken down from the internet). <a class="govuk-link" href="/contact/">Contact us</a> to do this.</li>
 <li><a class="govuk-link" href="/building-and-editing/#autocomplete">Autocomplete questions</a> won't work if any of the uploaded answers contains an '&' symbol. Some other special characters may also cause problems. We recommend you use only standard letters in your answers.</li>
 </ul>
-  <p><a class="govuk-link" href="#top">Back to top</a></p>
+  <p class="govuk-body"><a class="govuk-link" href="#top">Back to top</a></p>
 </section>
 <section class="content-section content-section--with-top-border">
   <h2 id="help" class="govuk-heading-m">Get help or report a bug</h2>
-<p>If you need help doing something or think you have found a bug (something doesn’t work as you expected), <a class="govuk-link" href="/contact/">contact us by email or on Slack</a>.</p>
-<p><a class="govuk-link" href="#top">Back to top</a></p>
+<p class="govuk-body">If you need help doing something or think you have found a bug (something doesn’t work as you expected), <a class="govuk-link" href="/contact/">contact us by email or on Slack</a>.</p>
+<p class="govuk-body"><a class="govuk-link" href="#top">Back to top</a></p>
 </section>
 <section class="content-section content-section--with-top-border">
 <h2 id="feedback" class="govuk-heading-m">Give feedback</h2>
-<p><a class="govuk-link" href="/contact/">Contact us by email or on Slack</a> to tell us what you think of MoJ Forms and suggest improvements.</p>
-<p><a class="govuk-link" href="#top">Back to top</a></p>
+<p class="govuk-body"><a class="govuk-link" href="/contact/">Contact us by email or on Slack</a> to tell us what you think of MoJ Forms and suggest improvements.</p>
+<p class="govuk-body"><a class="govuk-link" href="#top">Back to top</a></p>
 </section>
 

--- a/source/user-guide.html.erb
+++ b/source/user-guide.html.erb
@@ -7,19 +7,6 @@ menu: top
 menuindex: 3
 layout: user_guide
 ---
-
-<div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
-  <div class="govuk-notification-banner__header">
-    <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
-      Important
-    </h2>
-  </div>
-  <div class="govuk-notification-banner__content">
-    <p class="govuk-notification-banner__heading">
-    We are no longer accepting new forms or new users on MoJ Forms. Read the latest on our <a class="govuk-link" href="/news/#next-steps-retiring-10062025">plans to retire MoJ Forms</a>.
-    </p>
-  </div>
-</div>
 <h1 class="govuk-heading-l"><%= current_page.data.heading%></h1>
 <!-- START CONTENT -->
 <p class="govuk-body-l">Learn how to build, configure and publish forms and get help when you need it.</p>

--- a/source/user-guide.html.erb
+++ b/source/user-guide.html.erb
@@ -20,17 +20,22 @@ layout: user_guide
     </p>
   </div>
 </div>
-
 <h1 class="govuk-heading-l"><%= current_page.data.heading%></h1>
 <!-- START CONTENT -->
 <p class="govuk-body-l">Learn how to build, configure and publish forms and get help when you need it.</p>
 <h2 class="govuk-heading-m">Contents</h2>
 <%= partial "toc", locals: { links: { 
+  'requirements': "Requirements for forms",
   'access': "Getting access and signing in",
   'issues': "Known issues",
   'help': "Get help or report a bug",
   'feedback': "Give feedabck"
 }} %>
+<section class="content-section content-section--with-top-border">
+  <h2 id="requirements" class="govuk-heading-m">Requirements for forms</h2>
+  <p>THIS IS A NEW SECTION content TBC</p>
+  <p><a class="govuk-link" href="#top">Back to top</a></p>
+</section>
 <section class="content-section content-section--with-top-border">
   <h2 id="access" class="govuk-heading-m">Getting access and signing in</h2>
   <p>MoJ Forms is only available to employees of MoJ and its agencies and public bodies. To request access, <a class="govuk-link" href="/contact">contact us</a> to discuss your requirements. As MoJ Forms is still in development, we need your consent to take part in ongoing research.</p>

--- a/source/user-guide.html.erb
+++ b/source/user-guide.html.erb
@@ -29,7 +29,7 @@ layout: user_guide
   <li>be used for legitimate MoJ purposes</li>
   <li>comply with data protection guidelines and regulations</li>
   <li>comply with accessibility guidelines and regulations</li>
-  <li>be maintained and managed through its lifetime</li>
+  <li>be maintained and managed through their lifetime</li>
   </ul>
   <p class="govuk-body"><a class="govuk-link" href="#top">Back to top</a></p>
 </section>


### PR DESCRIPTION
Content changes to support reinstating a new form button on the MoJ Forms editor, including:

- new positioning statement on the homepage
- new MoJ Forms and GOV.UK Forms comparison page
- updates to the user guide
- backfilling a missing new item